### PR TITLE
Fixing a problem with flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ const (
 )
 
 func init() {
-	promlogConfig := &promlog.Config{}
+	promlogConfig = &promlog.Config{}
 	logger = promlog.New(promlogConfig)
 }
 


### PR DESCRIPTION
Since promlogConfig was moved to the init() function, we need to re-assign the variable to a promlogConfig that was already declared earlier in the function.