### PR TITLE
switch to JSONencoder for logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,9 +55,7 @@ func main() {
 	flag.StringVar(&metricsPath, "telemetry-path", "/metrics", "Path at which pipeline-service metrics are exported.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	klog.InitFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
This PR is for aligning [Exporter logs with ADR-6](https://issues.redhat.com/projects/PLNSRVCE/issues/PLNSRVCE-1290).
 
Here's a sample output after switch to JSON endoer
```
➜  pipeline-service-exporter (main) go run main.go                                                                               ✭ ✱
{"level":"info","ts":1688390488.3012707,"logger":"main","msg":"Starting pipeline_service_exporter","version":"(version=, branch=, revision=unknown)"}
{"level":"info","ts":1688390488.301288,"logger":"main","msg":"Build context","build":"(go=go1.20.5, platform=linux/amd64, user=, date=)"}
{"level":"info","ts":1688390488.301291,"logger":"main","msg":"Starting Server: ","listen_address":":9117"}
{"level":"info","ts":1688390499.6877043,"logger":"controller","msg":"get of pipelinerun CRD returned successfully"}
I0703 18:51:41.558453  369507 request.go:690] Waited for 1.046846234s due to client-side throttling, not priority and fairness, request: GET:https://a105312d9c2654c8c9f4319765d25350-726d418b983b2e6c.elb.us-east-1.amazonaws.com:6443/apis/flowcontrol.apiserver.k8s.io/v1beta1?timeout=32s
{"level":"info","ts":1688390506.781838,"logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":":9117"}
{"level":"info","ts":1688390506.7819881,"logger":"main","msg":"Starting controller-runtime manager"}
{"level":"info","ts":1688390506.7820272,"msg":"Starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":1688390506.7820387,"msg":"Starting server","path":"/metrics","kind":"metrics","addr":"[::]:9117"}
{"level":"info","ts":1688390506.7820816,"msg":"Starting EventSource","controller":"pipelinerun","controllerGroup":"tekton.dev","controllerKind":"PipelineRun","source":"kind source: *v1beta1.PipelineRun"}
{"level":"info","ts":1688390506.78209,"msg":"Starting Controller","controller":"pipelinerun","controllerGroup":"tekton.dev","controllerKind":"PipelineRun"}
{"level":"info","ts":1688390507.1824684,"msg":"Starting workers","controller":"pipelinerun","controllerGroup":"tekton.dev","controllerKind":"PipelineRun","worker count":1}
^C{"level":"info","ts":1688390534.8751037,"msg":"Stopping and waiting for non leader election runnables"}
{"level":"info","ts":1688390534.875172,"msg":"Stopping and waiting for leader election runnables"}
{"level":"info","ts":1688390534.8751929,"msg":"Shutdown signal received, waiting for all workers to finish","controller":"pipelinerun","controllerGroup":"tekton.dev","controllerKind":"PipelineRun"}
{"level":"info","ts":1688390534.8752408,"msg":"All workers finished","controller":"pipelinerun","controllerGroup":"tekton.dev","controllerKind":"PipelineRun"}
{"level":"info","ts":1688390534.8752677,"msg":"Stopping and waiting for caches"}
{"level":"info","ts":1688390534.8753486,"msg":"Stopping and waiting for webhooks"}
{"level":"info","ts":1688390534.875391,"msg":"Wait completed, proceeding to shutdown the manager"}

```