### PR TITLE
PLNSRVCE-1407: performance workgroup motivated metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ With this exporter, we can track important metrics such as PipelineRun durations
 
 The exporter is designed to integrate into Stonesoup Monitoring dashboards, allowing easy monitoring and visualization of the metrics that are most important.
 
+The exporter also allows for configuration of both which metrics are maintained and which labels are utilized for a given metric.
+
+See [the metrics specification](docs/metrics-specification.md) for details.
+
 ### Development Mode
 
 Make sure to set the KUBECONFIG env variable to point to the kubeconfig of your kubernetes cluster.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -17,32 +17,210 @@
 package collector
 
 import (
+	"context"
+	"fmt"
+	"os"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-// PipelineServiceCollector struct
-type PipelineServiceCollector struct {
+const (
+	ENABLE_PIPELINERUN_SCHEDULED_DURATION_PIPELINENAME_LABEL = "ENABLE_PIPELINERUN_SCHEDULED_DURATION_PIPELINENAME_LABEL"
+	ENABLE_TASKRUN_SCHEDULED_DURATION_TASKNAME_LABEL         = "ENABLE_TASKRUN_SCHEDULED_DURATION_TASKNAME_LABEL"
+	ENABLE_GAP_METRIC                                        = "ENABLE_GAP_METRIC"
+	NS_LABEL                                                 = "namespace"
+	PIPELINE_NAME_LABEL                                      = "pipelinename"
+	TASK_NAME_LABEL                                          = "taskname"
+	COMPLETED_LABEL                                          = "completed"
+	UPCOMING_LABEL                                           = "upcoming"
+)
+
+type PipelineRunScheduledCollector struct {
 	durationScheduled *prometheus.HistogramVec
+	prSchedNameLabel  bool
 }
 
-func NewCollector() *PipelineServiceCollector {
+type PipelineRunTaskRunGapCollector struct {
+	trGaps *prometheus.HistogramVec
+}
+
+type TaskRunCollector struct {
+	durationScheduled *prometheus.HistogramVec
+	trSchedNameLabel  bool
+}
+
+func optionalLabelEnabled(labelName string) bool {
+	env := os.Getenv(labelName)
+	enabled := len(env) > 0
+	// any random setting means true
+	if enabled {
+		// allow for users to turn off by setting to false
+		bv, err := strconv.ParseBool(env)
+		if err == nil && !bv {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+func NewPipelineRunScheduledCollector() *PipelineRunScheduledCollector {
+	labelNames := []string{NS_LABEL}
+	prSchedStatNameEnabled := optionalLabelEnabled(ENABLE_PIPELINERUN_SCHEDULED_DURATION_PIPELINENAME_LABEL)
+	if prSchedStatNameEnabled {
+		labelNames = append(labelNames, PIPELINE_NAME_LABEL)
+	}
 	durationScheduled := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "pipelinerun_duration_scheduled_seconds",
 		Help: "Duration in seconds for a PipelineRun to be scheduled.",
 		// reminder: exponential buckets need a start value greater than 0
 		// the results in buckets of 0.1, 0.5, 2.5, 12.5, 62.5, 312.5 seconds
 		Buckets: prometheus.ExponentialBuckets(0.1, 5, 6),
-	}, []string{"namespace"})
+	}, labelNames)
 
-	pipelineServiceCollector := &PipelineServiceCollector{
+	pipelineRunScheduledCollector := &PipelineRunScheduledCollector{
 		durationScheduled: durationScheduled,
+		prSchedNameLabel:  prSchedStatNameEnabled,
 	}
 	metrics.Registry.MustRegister(durationScheduled)
 
-	return pipelineServiceCollector
+	return pipelineRunScheduledCollector
 }
 
-func (c *PipelineServiceCollector) bumpScheduledDuration(ns string, scheduleDuration float64) {
-	c.durationScheduled.WithLabelValues(ns).Observe(scheduleDuration)
+func (c *PipelineRunScheduledCollector) bumpScheduledDuration(pr *v1beta1.PipelineRun, scheduleDuration float64) {
+	labels := map[string]string{NS_LABEL: pr.Namespace}
+	switch {
+	case c.prSchedNameLabel:
+		val := ""
+		if pr.Spec.PipelineRef != nil {
+			val = pr.Spec.PipelineRef.Name
+		} else {
+			val = pr.Name
+		}
+		labels[PIPELINE_NAME_LABEL] = val
+
+	}
+	c.durationScheduled.With(labels).Observe(scheduleDuration)
+}
+
+func NewPipelineRunTaskRunGapCollector() *PipelineRunTaskRunGapCollector {
+	labelNames := []string{NS_LABEL}
+	trGaps := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "pipelinerun_duration_between_taskruns_milliseconds",
+		Help: "Duration in milliseconds between a taskrun completing and the next taskrun being created within a pipelinerun.  If a pipelinerun only has one taskrun, use pipelinerun_duration_scheduled_seconds.",
+		// reminder: exponential buckets need a start value greater than 0
+		// the results in buckets of 0.1, 0.5, 2.5, 12.5, 62.5, 312.5 milliseconds
+		Buckets: prometheus.ExponentialBuckets(0.1, 5, 6),
+	}, append(labelNames, PIPELINE_NAME_LABEL, COMPLETED_LABEL, UPCOMING_LABEL))
+
+	pipelineRunTaskRunGapCollector := &PipelineRunTaskRunGapCollector{
+		trGaps: trGaps,
+	}
+	metrics.Registry.MustRegister(trGaps)
+
+	return pipelineRunTaskRunGapCollector
+}
+
+func (c *PipelineRunTaskRunGapCollector) bumpGapDuration(pr *v1beta1.PipelineRun, oc client.Client, ctx context.Context) {
+	labels := map[string]string{NS_LABEL: pr.Namespace}
+	val := ""
+	if pr.Spec.PipelineRef != nil {
+		val = pr.Spec.PipelineRef.Name
+	} else {
+		val = pr.Name
+	}
+	labels[PIPELINE_NAME_LABEL] = val
+
+	if len(pr.Status.ChildReferences) < 2 {
+		return
+	}
+
+	for index, kidRef := range pr.Status.ChildReferences {
+		if kidRef.Kind != "TaskRun" {
+			continue
+		}
+		if index == 0 {
+			kid := &v1beta1.TaskRun{}
+			err := oc.Get(ctx, types.NamespacedName{Namespace: pr.Namespace, Name: kidRef.Name}, kid)
+			if err != nil {
+				ctrl.Log.Info(fmt.Sprintf("could not calcuate gap for taskrun %s:%s: %s", pr.Namespace, kidRef.Name, err.Error()))
+				continue
+			}
+			gap := kid.CreationTimestamp.Time.Sub(pr.CreationTimestamp.Time)
+			labels[COMPLETED_LABEL] = pr.Name
+			labels[UPCOMING_LABEL] = kid.Name
+			c.trGaps.With(labels).Observe(float64(gap.Milliseconds()))
+			continue
+		}
+
+		prevKidRef := pr.Status.ChildReferences[index-1]
+		if prevKidRef.Kind != "TaskRun" {
+			continue
+		}
+		kid := &v1beta1.TaskRun{}
+		err := oc.Get(ctx, types.NamespacedName{Namespace: pr.Namespace, Name: kidRef.Name}, kid)
+		if err != nil {
+			ctrl.Log.Info(fmt.Sprintf("could not calcuate gap for taskrun %s:%s: %s", pr.Namespace, kidRef.Name, err.Error()))
+			continue
+		}
+		prevKid := &v1beta1.TaskRun{}
+		err = oc.Get(ctx, types.NamespacedName{Namespace: pr.Namespace, Name: prevKidRef.Name}, prevKid)
+		if err != nil {
+			ctrl.Log.Info(fmt.Sprintf("could not calcuate gap for taskrun %s:%s: %s", pr.Namespace, prevKidRef.Name, err.Error()))
+			continue
+		}
+
+		gap := kid.CreationTimestamp.Time.Sub(prevKid.Status.CompletionTime.Time).Milliseconds()
+		labels[COMPLETED_LABEL] = prevKidRef.Name
+		labels[UPCOMING_LABEL] = kidRef.Name
+		c.trGaps.With(labels).Observe(float64(gap))
+	}
+
+	return
+}
+
+func NewTaskRunCollector() *TaskRunCollector {
+	labelNames := []string{NS_LABEL}
+	trSchedStatNameEnabled := optionalLabelEnabled(ENABLE_TASKRUN_SCHEDULED_DURATION_TASKNAME_LABEL)
+	if trSchedStatNameEnabled {
+		labelNames = append(labelNames, TASK_NAME_LABEL)
+	}
+	durationScheduled := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "taskrun_duration_scheduled_seconds",
+		Help: "Duration in seconds for a TaskRun to be scheduled.",
+		// reminder: exponential buckets need a start value greater than 0
+		// the results in buckets of 0.1, 0.5, 2.5, 12.5, 62.5, 312.5 seconds
+		Buckets: prometheus.ExponentialBuckets(0.1, 5, 6),
+	}, labelNames)
+
+	taskRunCollector := &TaskRunCollector{
+		durationScheduled: durationScheduled,
+		trSchedNameLabel:  trSchedStatNameEnabled,
+	}
+	metrics.Registry.MustRegister(durationScheduled)
+
+	return taskRunCollector
+
+}
+
+func (c *TaskRunCollector) bumpScheduledDuration(tr *v1beta1.TaskRun, scheduleDuration float64) {
+	labels := map[string]string{NS_LABEL: tr.Namespace}
+	switch {
+	case c.trSchedNameLabel:
+		val := ""
+		if tr.Spec.TaskRef != nil {
+			val = tr.Spec.TaskRef.Name
+		} else {
+			val = tr.Name
+		}
+		labels[TASK_NAME_LABEL] = val
+
+	}
+	c.durationScheduled.With(labels).Observe(scheduleDuration)
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -19,12 +19,58 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func TestMetricCollection(t *testing.T) {
+func TestPipelineRunCollection(t *testing.T) {
 	objs := []client.Object{}
 	scheme := runtime.NewScheme()
 	_ = v1beta1.AddToScheme(scheme)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 
+	mockTaskRuns := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-taskrun-1",
+				Namespace:         "test-namespace",
+				UID:               types.UID("test-taskrun-1"),
+				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 0,
+					Conditions: duckv1.Conditions{{
+						Type:   "Succeeded",
+						Status: corev1.ConditionTrue,
+					}},
+					Annotations: nil,
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
+					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-taskrun-2",
+				Namespace:         "test-namespace",
+				UID:               types.UID("test-taskrun-2"),
+				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 0,
+					Conditions: duckv1.Conditions{{
+						Type:   "Succeeded",
+						Status: corev1.ConditionTrue,
+					}},
+					Annotations: nil,
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
+					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				},
+			},
+		},
+	}
 	mockPipelineRuns := []*v1beta1.PipelineRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -70,11 +116,133 @@ func TestMetricCollection(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-pipelinerun-3",
+				Namespace:         "test-namespace",
+				UID:               types.UID("test-pipelinerun-3"),
+				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 0,
+					Conditions: duckv1.Conditions{{
+						Type:   "Succeeded",
+						Status: corev1.ConditionTrue,
+					}},
+					Annotations: nil,
+				},
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					ChildReferences: []v1beta1.ChildStatusReference{
+						{
+							TypeMeta: runtime.TypeMeta{
+								Kind: "TaskRun",
+							},
+							Name: "test-taskrun-1",
+						},
+						{
+							TypeMeta: runtime.TypeMeta{
+								Kind: "TaskRun",
+							},
+							Name: "test-taskrun-2",
+						},
+					},
+					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
+					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				},
+			},
+		},
 	}
-	reconciler := &ReconcilePipelineRun{client: c, psCollector: NewCollector()}
+	schedReconciler := &ReconcilePipelineRunScheduled{client: c, prCollector: NewPipelineRunScheduledCollector()}
+	gapReconciler := &ReconcilePipelineRunTaskRunGap{client: c, prCollector: NewPipelineRunTaskRunGapCollector()}
 	ctx := context.TODO()
+	for _, tr := range mockTaskRuns {
+		err := c.Create(ctx, tr)
+		assert.NoError(t, err)
+	}
 	for _, pr := range mockPipelineRuns {
-		err := c.Create(context.TODO(), pr)
+		err := c.Create(ctx, pr)
+		assert.NoError(t, err)
+		request := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: pr.Namespace,
+				Name:      pr.Name,
+			},
+		}
+		_, err = schedReconciler.Reconcile(ctx, request)
+		_, err = gapReconciler.Reconcile(ctx, request)
+	}
+
+	label := prometheus.Labels{NS_LABEL: "test-namespace"}
+	g, e := schedReconciler.prCollector.durationScheduled.GetMetricWith(label)
+	assert.NoError(t, e)
+	assert.NotNil(t, g)
+	label = prometheus.Labels{NS_LABEL: "test-namespace", PIPELINE_NAME_LABEL: "test-pipelinerun-3", COMPLETED_LABEL: "test-pipelinerun-3", UPCOMING_LABEL: "test-taskrun-1"}
+	g, e = gapReconciler.prCollector.trGaps.GetMetricWith(label)
+	assert.NoError(t, e)
+	assert.NotNil(t, g)
+	label = prometheus.Labels{NS_LABEL: "test-namespace", PIPELINE_NAME_LABEL: "test-pipelinerun-3", COMPLETED_LABEL: "test-pipelinerun-1", UPCOMING_LABEL: "test-taskrun-2"}
+	g, e = gapReconciler.prCollector.trGaps.GetMetricWith(label)
+	assert.NoError(t, e)
+	assert.NotNil(t, g)
+}
+
+func TestTaskRunCollection(t *testing.T) {
+	objs := []client.Object{}
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	mockTaskRuns := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-taskrun-1",
+				Namespace:         "test-namespace",
+				UID:               types.UID("test-taskrun-1"),
+				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 0,
+					Conditions: duckv1.Conditions{{
+						Type:   "Succeeded",
+						Status: corev1.ConditionTrue,
+					}},
+					Annotations: nil,
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
+					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-taskrun-2",
+				Namespace:         "test-namespace",
+				UID:               types.UID("test-taskrun-2"),
+				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 0,
+					Conditions: duckv1.Conditions{{
+						Type:   "Succeeded",
+						Status: corev1.ConditionTrue,
+					}},
+					Annotations: nil,
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
+					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				},
+			},
+		},
+	}
+	reconciler := &ReconcileTaskRun{client: c, trCollector: NewTaskRunCollector()}
+	ctx := context.TODO()
+	for _, pr := range mockTaskRuns {
+		err := c.Create(ctx, pr)
 		assert.NoError(t, err)
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -85,8 +253,8 @@ func TestMetricCollection(t *testing.T) {
 		_, err = reconciler.Reconcile(ctx, request)
 	}
 
-	label := prometheus.Labels{"namespace": "test-namespace"}
-	g, e := reconciler.psCollector.durationScheduled.GetMetricWith(label)
+	label := prometheus.Labels{NS_LABEL: "test-namespace"}
+	g, e := reconciler.trCollector.durationScheduled.GetMetricWith(label)
 	assert.NoError(t, e)
 	assert.NotNil(t, g)
 }

--- a/collector/controller.go
+++ b/collector/controller.go
@@ -63,5 +63,15 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 		return nil, err
 	}
 
+	err = SetupPipelineRunTaskRunGapController(mgr)
+	if err != nil {
+		return nil, err
+	}
+
+	err = SetupTaskRunController(mgr)
+	if err != nil {
+		return nil, err
+	}
+
 	return mgr, nil
 }

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -18,20 +18,20 @@ package collector
 
 import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"time"
 )
 
-func calculateScheduledDuration(pipelineRun *v1beta1.PipelineRun) float64 {
-	var durationScheduled float64
-
-	// Fetch the creation and scheduled times
-	createdTime := pipelineRun.ObjectMeta.CreationTimestamp.Time
-	startTime := pipelineRun.Status.StartTime.Time
-
-	// Check if either one of these values is zero
-	if createdTime.IsZero() || startTime.IsZero() {
+func calcuateScheduledDuration(created, started time.Time) float64 {
+	if created.IsZero() || started.IsZero() {
 		return 0
 	}
+	return started.Sub(created).Seconds()
+}
 
-	durationScheduled = startTime.Sub(createdTime).Seconds()
-	return durationScheduled
+func calculateScheduledDurationPipelineRun(pipelineRun *v1beta1.PipelineRun) float64 {
+	return calcuateScheduledDuration(pipelineRun.CreationTimestamp.Time, pipelineRun.Status.StartTime.Time)
+}
+
+func calculateScheduledDurationTaskRun(taskrun *v1beta1.TaskRun) float64 {
+	return calcuateScheduledDuration(taskrun.CreationTimestamp.Time, taskrun.Status.StartTime.Time)
 }

--- a/collector/metrics_test.go
+++ b/collector/metrics_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 )
 
-func TestCalculateScheduledDuration(t *testing.T) {
+func TestCalculatePipelineRunScheduledDuration(t *testing.T) {
 	// Create mock PipelineRuns data
 	mockPipelineRuns := []*v1beta1.PipelineRun{
 		{
@@ -74,7 +74,65 @@ func TestCalculateScheduledDuration(t *testing.T) {
 
 	for _, pr := range mockPipelineRuns {
 		want := 5
-		got := int(calculateScheduledDuration(pr))
+		got := int(calculateScheduledDurationPipelineRun(pr))
+
+		if got != want {
+			t.Errorf("Scheduled Duration is not as expected. Got %d, expected %d", got, want)
+		}
+	}
+
+}
+
+func TestCalculateTaskRunScheduledDuration(t *testing.T) {
+	// Create mock TaskRuns data
+	mockTaskRuns := []*v1beta1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-taskrun-1",
+				Namespace:         "test-namespace",
+				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 0,
+					Conditions: duckv1.Conditions{{
+						Type:   "Succeeded",
+						Status: corev1.ConditionTrue,
+					}},
+					Annotations: nil,
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
+					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-taskrun-1",
+				Namespace:         "test-namespace",
+				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
+			},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 0,
+					Conditions: duckv1.Conditions{{
+						Type:   "Failed",
+						Status: corev1.ConditionTrue,
+					}},
+					Annotations: nil,
+				},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
+					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				},
+			},
+		},
+	}
+
+	for _, tr := range mockTaskRuns {
+		want := 5
+		got := int(calculateScheduledDurationTaskRun(tr))
 
 		if got != want {
 			t.Errorf("Scheduled Duration is not as expected. Got %d, expected %d", got, want)

--- a/collector/taskrun.go
+++ b/collector/taskrun.go
@@ -1,0 +1,83 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type ReconcileTaskRun struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+	trCollector   *TaskRunCollector
+}
+
+type trStartTimeEventFilter struct {
+}
+
+func (f *trStartTimeEventFilter) Create(event.CreateEvent) bool {
+	return false
+}
+
+func (f *trStartTimeEventFilter) Generic(event.GenericEvent) bool {
+	return false
+}
+
+func (f *trStartTimeEventFilter) Delete(event.DeleteEvent) bool {
+	return false
+}
+
+func (f *trStartTimeEventFilter) Update(e event.UpdateEvent) bool {
+	//TODO remember, keep track of when pipeline-service and RHTAP starts moving from v1beta1 to v1
+	oldTR, okold := e.ObjectOld.(*v1beta1.TaskRun)
+	newTR, oknew := e.ObjectNew.(*v1beta1.TaskRun)
+	if okold && oknew {
+		if oldTR.Status.StartTime == nil && newTR.Status.StartTime != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func SetupTaskRunController(mgr ctrl.Manager) error {
+	reconciler := &ReconcileTaskRun{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		eventRecorder: mgr.GetEventRecorderFor("MetricExporterTaskRuns"),
+		trCollector:   NewTaskRunCollector(),
+	}
+	return ctrl.NewControllerManagedBy(mgr).For(&v1beta1.TaskRun{}).WithEventFilter(&trStartTimeEventFilter{}).Complete(reconciler)
+}
+
+func (r *ReconcileTaskRun) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+	log := log.FromContext(ctx)
+
+	//TODO remember, keep track of when pipeline-service and RHTAP starts moving from v1beta1 to v1
+	tr := &v1beta1.TaskRun{}
+	err := r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: request.Name}, tr)
+	if err != nil && !errors.IsNotFound(err) {
+		return reconcile.Result{}, err
+	}
+	if err != nil {
+		log.V(4).Info(fmt.Sprintf("ignoring deleted taskrun %q", request.NamespacedName))
+		return reconcile.Result{}, nil
+	}
+
+	// based on our WithEventFilter we should only be getting called with the start time is set
+	log.V(4).Info(fmt.Sprintf("recording schedule duration for %q", request.NamespacedName))
+	r.trCollector.bumpScheduledDuration(tr, calculateScheduledDurationTaskRun(tr))
+	return reconcile.Result{}, nil
+}

--- a/docs/metrics-specification.md
+++ b/docs/metrics-specification.md
@@ -6,31 +6,36 @@ This document outlines the specifications for a Prometheus exporter that collect
 ### Metrics Definition:
 
 _**PipelineRun Scheduling Duration:**_  
-The duration of time taken for a PipelineRun to be scheduled, calculated as the difference between the creation timestamp and the start time of the PipelineRun. 
+The duration of time in seconds taken for a PipelineRun to be scheduled, calculated as the difference between the creation timestamp and the start time of the PipelineRun. 
 
-_Metric Name:_ pipeline_run_scheduling_duration  
-_Labels:_ None  
-_Data Type:_ Gauge  
+_Metric Name:_ pipelinerun_scheduling_duration  
+_Labels:_ Minimally a `namespace` label.  If the `ENABLE_PIPELINERUN_SCHEDULED_DURATION_PIPELINENAME_LABEL` environment variable is set to `true` on the exporter deployment, the `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.
+_Data Type:_ Histogram
 _Description:_ The time taken in seconds for a PipelineRun to be scheduled.
 
-_**PipelineRun Completion Duration:**_  
-The duration of time taken for a PipelineRun to complete, calculated as the difference between the start time and the completion time of the PipelineRun.  
-_Metric Name:_ pipeline_run_completion_duration  
-_Labels:_ None  
-_Data Type:_ Gauge  
-_Description:_ The time taken in seconds for a PipelineRun to complete.
+_**TaskRun Scheduling Duration:**_  
+The duration of time in seconds taken for a TaskRun to be scheduled, calculated as the difference between the creation timestamp and the start time of the TaskRun.
 
-### Data Collection:
-The data for these metrics will be collected from the status.startTime, status.completionTime, and metadata.creationTimestamp fields of PipelineRun objects in Pipeline Service.
+_Metric Name:_ taskrunrun_scheduling_duration  
+_Labels:_ Minimally a `namespace` label.  If the `ENABLE_TASKRUN_SCHEDULED_DURATION_TASKNAME_LABEL` environment variable is set to `true` on the exporter deployment, the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
+_Data Type:_ Histogram
+_Description:_ The time taken in seconds for a TaskRun to be scheduled.
 
-### Data Processing:
-No data processing is required.
+
+_**Scheduling Duration of different TaskRuns with a PipelineRun:**_
+The time taken in milliseconds between the creation of the first TaskRun and the creation of its PipelineRun, followed by the duration in milliseconds between the completion of a preceding TaskRun and the creation of the following TaskRun.  This metrics currently assumes sequential TaskRuns, and the parallel TaskRuns within a PipelineRun are not employed.  At this time, this metric is disabled by default, but can be enabled by setting the environment variable `ENABLE_GAP_METRIC` to `true`.
+
+_Metric Name:_ pipelinerun_duration_between_taskruns_milliseconds
+_Labels:_ `namespace`, `pipelinename`, `completed`, `upcoming`.  The `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.  The `completed` label is set either the PipelineRun name if we are dealing with the first Taskrun, or the name of the latest TaskRun to be completed.  The `upcoming` label is set to the name of the TaskRun that is created but not yet complete.
+_Data Type_: Histogram
+_Description_: The taken between TaskRuns within a PipelineRun
+
 
 ### Metrics Format:
-The metrics will be exposed in Prometheus' text-based exposition format using a HTTP endpoint.
+The metrics will be exposed via the Prometheus integration with the Kubernetes Controller Runtime framework.
 
 ### Performance Requirements:
-The exporter will collect data every 60 seconds and respond within 200 milliseconds. The exporter would be able to handle a high volume of data and scale to meet the needs of the Pipeline Service.
+To avoid prior issues with memory creep, excessive restarts, and excessive load on the API server, controller / watch based monitoring of PipelineRuns and TaskRuns are employed.  No access to those object should be performed with a non-caching client, only the controller's caching client.
 
 ### Security Considerations:
 The exporter will implement appropriate security measures to ensure that sensitive data is not exposed.

--- a/main.go
+++ b/main.go
@@ -38,10 +38,6 @@ var (
 	promlogConfig *promlog.Config
 )
 
-const (
-	exporterName = "pipeline_service_exporter"
-)
-
 func init() {
 	promlogConfig = &promlog.Config{}
 }


### PR DESCRIPTION
1) while @adambkaplan and I initially tried to minimize cardinality of the metrics, he and I had a conversation where we agreed that we needed to add a way to opt into greater cardinality; minimally during our performance testing; perhaps on by default long term;  added a commit which allows for adding the pipeline name as a label on the scheduled duration metric
2) added a task run level scheduled duration metric, with opt into a task name label, as an alternative to `tekton_pipelines_controller_taskruns_pod_latency_*` from upstream, where both @jhutar and I have seen odd results
3) added a new metric to highlight the gap in time between the scheduling of sequential  taskruns within a pipelinerun