### PR TITLE
PLNSRVCE-1407: second pass at taskrun gap metric

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -177,14 +177,223 @@ func TestPipelineRunCollection(t *testing.T) {
 	g, e := schedReconciler.prCollector.durationScheduled.GetMetricWith(label)
 	assert.NoError(t, e)
 	assert.NotNil(t, g)
-	label = prometheus.Labels{NS_LABEL: "test-namespace", PIPELINE_NAME_LABEL: "test-pipelinerun-3", COMPLETED_LABEL: "test-pipelinerun-3", UPCOMING_LABEL: "test-taskrun-1"}
+	label = prometheus.Labels{NS_LABEL: "test-namespace"}
 	g, e = gapReconciler.prCollector.trGaps.GetMetricWith(label)
 	assert.NoError(t, e)
 	assert.NotNil(t, g)
-	label = prometheus.Labels{NS_LABEL: "test-namespace", PIPELINE_NAME_LABEL: "test-pipelinerun-3", COMPLETED_LABEL: "test-pipelinerun-1", UPCOMING_LABEL: "test-taskrun-2"}
+	label = prometheus.Labels{NS_LABEL: "test-namespace"}
 	g, e = gapReconciler.prCollector.trGaps.GetMetricWith(label)
 	assert.NoError(t, e)
 	assert.NotNil(t, g)
+}
+
+func TestPipelineRunPipelineRef(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		expectedReturn string
+		pr             *v1beta1.PipelineRun
+	}{
+		{
+			name:           "use pipeline run name",
+			expectedReturn: "test-pipelinerun",
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pipelinerun",
+				},
+			},
+		},
+		{
+			name:           "use pipelinerun run generate name",
+			expectedReturn: "test-pipelinerun-",
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "test-pipelinerun-foo",
+					GenerateName: "test-pipelinerun-",
+				},
+			},
+		},
+		{
+			name:           "use pipeline run ref param name",
+			expectedReturn: "test-pipeline",
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "test-pipelinerun-foo",
+					GenerateName: "test-pipelinerun-",
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineRef: &v1beta1.PipelineRef{
+						ResolverRef: v1beta1.ResolverRef{
+							Params: []v1beta1.Param{
+								{
+									Name: "name",
+									Value: v1beta1.ParamValue{
+										StringVal: "test-pipeline"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "use pipeline run ref name",
+			expectedReturn: "test-pipeline",
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "test-pipelinerun-foo",
+					GenerateName: "test-pipelinerun-",
+				},
+				Spec: v1beta1.PipelineRunSpec{PipelineRef: &v1beta1.PipelineRef{Name: "test-pipeline"}},
+			},
+		},
+	} {
+		ret := pipelineRunPipelineRef(test.pr)
+		if ret != test.expectedReturn {
+			t.Errorf("test %s expected %s got %s", test.name, test.expectedReturn, ret)
+		}
+	}
+}
+
+func TestTaskRunTaskRefName(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		expectedReturn string
+		tr             *v1beta1.TaskRun
+		pr             *v1beta1.PipelineRun
+	}{
+		{
+			name:           "use task run name",
+			expectedReturn: "test-taskrun",
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-taskrun",
+				},
+			},
+		},
+		{
+			name:           "use task run generate name",
+			expectedReturn: "test-taskrun-",
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "test-taskrun-foo",
+					GenerateName: "test-taskrun-",
+				},
+			},
+		},
+		{
+			name:           "use task run ref param name",
+			expectedReturn: "test-task",
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "test-taskrun-foo",
+					GenerateName: "test-taskrun-",
+				},
+				Spec: v1beta1.TaskRunSpec{
+					TaskRef: &v1beta1.TaskRef{
+						ResolverRef: v1beta1.ResolverRef{
+							Params: []v1beta1.Param{
+								{
+									Name: "name",
+									Value: v1beta1.ParamValue{
+										StringVal: "test-task"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "use task run ref name",
+			expectedReturn: "test-task",
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "test-taskrun-foo",
+					GenerateName: "test-taskrun-",
+				},
+				Spec: v1beta1.TaskRunSpec{TaskRef: &v1beta1.TaskRef{Name: "test-task"}},
+			},
+		},
+		{
+			name:           "use task run ref param name",
+			expectedReturn: "test-task",
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "test-taskrun-foo",
+					GenerateName: "test-taskrun-",
+				},
+				Spec: v1beta1.TaskRunSpec{TaskRef: &v1beta1.TaskRef{Name: "test-task"}},
+			},
+		},
+		{
+			name:           "use pipeline run pipeline spec tasks with name",
+			expectedReturn: "task1",
+			pr: &v1beta1.PipelineRun{
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineSpec: &v1beta1.PipelineSpec{
+						Tasks: []v1beta1.PipelineTask{
+							{
+								Name: "task1",
+							},
+						},
+					},
+				},
+			},
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-taskrun-task1",
+				},
+			},
+		},
+		{
+			name:           "use pipeline run pipeline spec tasks with param name",
+			expectedReturn: "task1",
+			pr: &v1beta1.PipelineRun{
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineSpec: &v1beta1.PipelineSpec{
+						Tasks: []v1beta1.PipelineTask{
+							{
+								Params: []v1beta1.Param{
+									{
+										Name:  "name",
+										Value: v1beta1.ParamValue{StringVal: "task1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-taskrun-task1",
+				},
+			},
+		},
+		{
+			name:           "use pipeline run spec task run spec",
+			expectedReturn: "task1",
+			pr: &v1beta1.PipelineRun{
+				Spec: v1beta1.PipelineRunSpec{
+					TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{
+						{
+							PipelineTaskName: "task1",
+						},
+					},
+				},
+			},
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-taskrun-task1",
+				},
+			},
+		},
+	} {
+		ret := taskRunTaskRef(test.tr, test.pr)
+		if ret != test.expectedReturn {
+			t.Errorf("test %s expected %s got %s", test.name, test.expectedReturn, ret)
+		}
+	}
 }
 
 func TestTaskRunCollection(t *testing.T) {

--- a/collector/pipelinerun.go
+++ b/collector/pipelinerun.go
@@ -140,9 +140,6 @@ func optionalMetricEnabled(envVarName string) bool {
 }
 
 func SetupPipelineRunTaskRunGapController(mgr ctrl.Manager) error {
-	if !optionalMetricEnabled(ENABLE_GAP_METRIC) {
-		return nil
-	}
 	reconciler := &ReconcilePipelineRunTaskRunGap{
 		client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),


### PR DESCRIPTION
- pivot and default to on, but with minimal labeling (namespace)
- with additional labels, added better logic around retrieval of task/pipeline name instead of dynamically generated run names