### PR TITLE
PLNSRVCE-1405: provide a metric for pipelineruns marked failed by tekton because pvc quota prevented required pvc(s) to be created

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -370,7 +370,7 @@ func validateHistogramVec(t *testing.T, h *prometheus.HistogramVec, labels prome
 	}
 }
 
-func validateGaugeVec(t *testing.T, g *prometheus.GaugeVec, labels prometheus.Labels) {
+func validateGaugeVec(t *testing.T, g *prometheus.GaugeVec, labels prometheus.Labels, count float64) {
 	gauge, err := g.GetMetricWith(labels)
 	assert.NoError(t, err)
 	assert.NotNil(t, gauge)
@@ -378,8 +378,7 @@ func validateGaugeVec(t *testing.T, g *prometheus.GaugeVec, labels prometheus.La
 	gauge.Write(metric)
 	assert.NotNil(t, metric.Gauge)
 	assert.NotNil(t, metric.Gauge.Value)
-	assert.NotZero(t, *metric.Gauge.Value)
-	assert.Greater(t, *metric.Gauge.Value, float64(-1))
+	assert.Equal(t, count, *metric.Gauge.Value)
 }
 
 func pipelineRunFromActualRHTAPYaml() ([]v1beta1.PipelineRun, error) {

--- a/collector/controller.go
+++ b/collector/controller.go
@@ -73,5 +73,10 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 		return nil, err
 	}
 
+	err = SetupPVCThrottledController(mgr)
+	if err != nil {
+		return nil, err
+	}
+
 	return mgr, nil
 }

--- a/collector/pipelinerun.go
+++ b/collector/pipelinerun.go
@@ -3,9 +3,14 @@ package collector
 import (
 	"context"
 	"fmt"
+	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
+	"knative.dev/pkg/apis"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
@@ -126,6 +131,139 @@ func (f *taskRunGapEventFilter) Generic(event.GenericEvent) bool {
 	return false
 }
 
+type ReconcilePVCThrottled struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+	prCollector   *ThrottledByPVCQuotaCollector
+	nsCache       map[string]struct{}
+	listMutex     sync.RWMutex
+}
+
+func (r *ReconcilePVCThrottled) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+	log := log.FromContext(ctx)
+
+	// so we don't collide with the periodic relist/reset in Start; we should still be able to process events concurrently
+	r.listMutex.RLock()
+	defer r.listMutex.RUnlock()
+
+	//TODO remember, keep track of when pipeline-service and RHTAP starts moving from v1beta1 to v1
+	pr := &v1beta1.PipelineRun{}
+	err := r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: request.Name}, pr)
+	if err != nil && !errors.IsNotFound(err) {
+		return reconcile.Result{}, err
+	}
+	if err != nil {
+		// given the various complexities around deletion processing and controllers, we do not decrement our
+		// metric in real time, but rather reset the metrics in our background poller attuned to the operator's pruner
+		// interval.
+		log.V(4).Info(fmt.Sprintf("processing deleted pipelinerun %q", request.NamespacedName))
+		return reconcile.Result{}, nil
+	}
+
+	// based on our WithEventFilter we should only be getting called if this got throttled by PVC
+	log.V(4).Info(fmt.Sprintf("recording pvc throttling for %q", request.NamespacedName))
+	r.prCollector.incPVCThrottle(pr)
+	return reconcile.Result{}, nil
+}
+
+// Start - we do a long running runnable to reset the metric in case we miss delete events, as controller relist does not duplicate
+// delete events like it can create/update events
+func (r *ReconcilePVCThrottled) Start(ctx context.Context) error {
+	//this matches the scheduling interval for pruner in the operator's TektonConfig object
+	//for now we are going to refrain from reading in the TektonConfig, bringing in a 3rd party
+	// golang cronjob schedule parser, and pulling the value; but if we end up changing it with
+	// some frequency, we'll start doing that
+	eventTicker := time.NewTicker(2 * time.Minute)
+	for {
+		select {
+		case <-eventTicker.C:
+			r.resetPVCStats(ctx)
+		case <-ctx.Done():
+			eventTicker.Stop()
+			return nil
+		}
+	}
+	return nil
+}
+
+func failedBecauseOfPVCQuota(pr *v1beta1.PipelineRun) bool {
+	c := pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded)
+	if c == nil {
+		return false
+	}
+	if !c.IsFalse() {
+		return false
+	}
+	if c.Reason != volumeclaim.ReasonCouldntCreateWorkspacePVC || !strings.Contains(c.Message, "exceeded quota") {
+		return false
+	}
+	return true
+}
+
+func (r *ReconcilePVCThrottled) resetPVCStats(ctx context.Context) {
+	r.listMutex.Lock()
+	defer r.listMutex.Unlock()
+	// originally considered using pvcThrottle.Reset() but wanted to allow for history based searches from metrics
+	// console, so we are trying keeping track of namespaces; for now, not worried about history across exporter restart
+	for ns := range r.nsCache {
+		r.prCollector.zeroPVCThrottle(ns)
+	}
+	prList := &v1beta1.PipelineRunList{}
+	err := r.client.List(ctx, prList)
+	nsWithPVCThrottle := map[string]struct{}{}
+	if err == nil {
+		for _, pr := range prList.Items {
+			r.nsCache[pr.Namespace] = struct{}{}
+			if failedBecauseOfPVCQuota(&pr) {
+				r.prCollector.incPVCThrottle(&pr)
+				nsWithPVCThrottle[pr.Namespace] = struct{}{}
+				continue
+			}
+			// in case this is a namespace we did not see in prior invocations of resetPVCStats,
+			// we want to get explicit 0 counts if there is not any PVC throttling for a namespace,
+			// but we make sure we did not increment it previously in this loop (that is easier/cheaper then getting the metric and then
+			// hydrating the value like we do in our unit tests), so we set to 0
+			_, ok := nsWithPVCThrottle[pr.Namespace]
+			if ok {
+				continue
+			}
+			r.prCollector.zeroPVCThrottle(pr.Namespace)
+		}
+	}
+}
+
+type pvcThrottledFilter struct {
+}
+
+func (f *pvcThrottledFilter) Create(event.CreateEvent) bool {
+	return false
+}
+
+func (f *pvcThrottledFilter) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (f *pvcThrottledFilter) Update(e event.UpdateEvent) bool {
+
+	//TODO remember, keep track of when pipeline-service and RHTAP starts moving from v1beta1 to v1
+	oldPR, okold := e.ObjectOld.(*v1beta1.PipelineRun)
+	newPR, oknew := e.ObjectNew.(*v1beta1.PipelineRun)
+	if okold && oknew {
+		if !failedBecauseOfPVCQuota(oldPR) && failedBecauseOfPVCQuota(newPR) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *pvcThrottledFilter) Generic(event.GenericEvent) bool {
+	return false
+}
+
 func optionalMetricEnabled(envVarName string) bool {
 	env := os.Getenv(envVarName)
 	enabled := len(env) > 0
@@ -172,4 +310,20 @@ func (r *ReconcilePipelineRunTaskRunGap) Reconcile(ctx context.Context, request 
 	log.V(4).Info(fmt.Sprintf("recording taskrun gap for %q", request.NamespacedName))
 	r.prCollector.bumpGapDuration(pr, r.client, ctx)
 	return reconcile.Result{}, nil
+}
+
+func SetupPVCThrottledController(mgr ctrl.Manager) error {
+	reconciler := &ReconcilePVCThrottled{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		eventRecorder: mgr.GetEventRecorderFor("MetricExporterPVCThrottled"),
+		prCollector:   NewPVCThrottledCollector(),
+		nsCache:       map[string]struct{}{},
+		listMutex:     sync.RWMutex{},
+	}
+	err := ctrl.NewControllerManagedBy(mgr).For(&v1beta1.PipelineRun{}).WithEventFilter(&pvcThrottledFilter{}).Complete(reconciler)
+	if err == nil {
+		mgr.Add(reconciler)
+	}
+	return err
 }

--- a/collector/pipelinerun_test.go
+++ b/collector/pipelinerun_test.go
@@ -1,7 +1,15 @@
 package collector
 
 import (
+	"context"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sync"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -11,6 +19,144 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
+
+func TestPvcThrottledFilter_Update(t *testing.T) {
+	filter := &pvcThrottledFilter{}
+	for _, tc := range []struct {
+		name       string
+		oldPR      *v1beta1.PipelineRun
+		newPR      *v1beta1.PipelineRun
+		expectedRC bool
+	}{
+		{
+			name:  "not failed",
+			oldPR: &v1beta1.PipelineRun{},
+			newPR: &v1beta1.PipelineRun{},
+		},
+		{
+			name:  "failed with right reason and message",
+			oldPR: &v1beta1.PipelineRun{},
+			newPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:    apis.ConditionSucceeded,
+								Status:  corev1.ConditionFalse,
+								Reason:  volumeclaim.ReasonCouldntCreateWorkspacePVC,
+								Message: "exceeded quota",
+							},
+						},
+					},
+				},
+			},
+			expectedRC: true,
+		},
+		{
+			name:  "failed with right reason but wrong message",
+			oldPR: &v1beta1.PipelineRun{},
+			newPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:    apis.ConditionSucceeded,
+								Status:  corev1.ConditionFalse,
+								Reason:  volumeclaim.ReasonCouldntCreateWorkspacePVC,
+								Message: "api server unavailable",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "failed with right message but wrong reason",
+			oldPR: &v1beta1.PipelineRun{},
+			newPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:    apis.ConditionSucceeded,
+								Status:  corev1.ConditionFalse,
+								Reason:  corev1.PodReasonUnschedulable,
+								Message: "exceeded quota",
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		ev := event.UpdateEvent{
+			ObjectOld: tc.oldPR,
+			ObjectNew: tc.newPR,
+		}
+		rc := filter.Update(ev)
+		if rc != tc.expectedRC {
+			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
+		}
+	}
+}
+
+func TestResetPVCStats(t *testing.T) {
+	objs := []client.Object{}
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	mockPipelineRuns := []*v1beta1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-1"},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						apis.Condition{
+							Type:    apis.ConditionSucceeded,
+							Status:  corev1.ConditionFalse,
+							Reason:  volumeclaim.ReasonCouldntCreateWorkspacePVC,
+							Message: "exceeded quota",
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-2"},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						apis.Condition{
+							Type:    apis.ConditionSucceeded,
+							Status:  corev1.ConditionFalse,
+							Reason:  volumeclaim.ReasonCouldntCreateWorkspacePVC,
+							Message: "exceeded quota",
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := context.TODO()
+	for _, pr := range mockPipelineRuns {
+		err := c.Create(ctx, pr)
+		assert.NoError(t, err)
+	}
+
+	pvcReconciler := &ReconcilePVCThrottled{client: c, prCollector: NewPVCThrottledCollector(), listMutex: sync.RWMutex{}, nsCache: map[string]struct{}{}}
+	pvcReconciler.resetPVCStats(ctx)
+	label := prometheus.Labels{NS_LABEL: "test-namespace"}
+	validateGaugeVec(t, pvcReconciler.prCollector.pvcThrottle, label, float64(2))
+	// second pass should reset and still be two
+	pvcReconciler.resetPVCStats(ctx)
+	validateGaugeVec(t, pvcReconciler.prCollector.pvcThrottle, label, float64(2))
+	// deletion, then another pass, should now be one
+	err := c.Delete(ctx, mockPipelineRuns[0])
+	assert.NoError(t, err)
+	pvcReconciler.resetPVCStats(ctx)
+	validateGaugeVec(t, pvcReconciler.prCollector.pvcThrottle, label, float64(1))
+}
 
 func TestStartTimeEventFilter_Update(t *testing.T) {
 	filter := &startTimeEventFilter{}

--- a/docs/metrics-specification.md
+++ b/docs/metrics-specification.md
@@ -5,8 +5,19 @@ This document outlines the specifications for a Prometheus exporter that collect
 
 ### Metrics Definition:
 
+_**PipelineRun Failed With PVC Quota:**_  
+The count of the number of current PipelineRuns on the cluster marked failed by Tekton because PVC Quota prevented creation of required PVCs. 
+The deletion of PipelineRuns that failed because of PVC limits is effectively a decrement of the metric.  That said, given the complexities around
+delete events and controllers (missed events not getting relisted, hit and miss success of tombstone objects, multiple events because of finalizers),
+we do not decrement in real time, but on our custom Runnable that resets the metric at the same interval the TektonConfig pruner is set to.
+
+_Metric Name:_ pipelinerun_failed_by_pvc_quota_count
+_Labels:_ `namespace` label.  Note:  K8s PVC quota specifications are a namespace scoped resource.
+_Data Type:_ Gauge
+_Description:_ The number of PipelineRuns marked failed because required PVCs could not be created.
+
 _**PipelineRun Scheduling Duration:**_  
-The duration of time in seconds taken for a PipelineRun to be scheduled, calculated as the difference between the creation timestamp and the start time of the PipelineRun. 
+The duration of time in seconds taken for a PipelineRun to be scheduled, calculated as the difference between the creation timestamp and the start time of the PipelineRun.
 
 _Metric Name:_ pipelinerun_scheduling_duration  
 _Labels:_ Minimally a `namespace` label.  If the `ENABLE_PIPELINERUN_SCHEDULED_DURATION_PIPELINENAME_LABEL` environment variable is set to `true` on the exporter deployment, the `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/openshift-pipelines/pipeline-service-exporter
 go 1.19
 
 require (
-	github.com/go-kit/log v0.2.1
 	github.com/go-logr/logr v1.2.4
 	github.com/prometheus/client_golang v1.14.0
+	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.40.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tektoncd/pipeline v0.45.0
@@ -30,6 +30,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
@@ -57,7 +58,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect


### PR DESCRIPTION

- implemented as a gauge, where deletion of failed pipelineruns is the "decrementing" action
- while a controller with caching client is created, and we increment in real time
- we also have a background controller runtime action which resets the metric, relists, and effectively handles deletes in that fashion
- real time processing of deletes for metrics too problematic given controller QofS around deletes
- unit tests and docs included
- geared towards alerting