### PR TITLE
PLNSRVCE-1443: make gap histogram buckets appropriate for milliseconds

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -58,7 +58,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 			},
 		}
 		_, err = gapReconciler.Reconcile(ctx, request)
-		label := prometheus.Labels{NS_LABEL: pr.Namespace}
+		label := prometheus.Labels{NS_LABEL: pr.Namespace, STATUS_LABEL: SUCCEEDED}
 		validateHistogramVec(t, gapReconciler.prCollector.trGaps, label, true)
 	}
 
@@ -189,7 +189,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 		_, err = gapReconciler.Reconcile(ctx, request)
 	}
 
-	label := prometheus.Labels{NS_LABEL: "test-namespace"}
+	label := prometheus.Labels{NS_LABEL: "test-namespace", STATUS_LABEL: SUCCEEDED}
 	validateHistogramVec(t, gapReconciler.prCollector.trGaps, label, false)
 
 }


### PR DESCRIPTION
The taskrun gap histogram metric still had the bucket specification that was copied and pasted from our existing histograms measured in seconds. Multipled by 1000 as needed to shift the buckets appropriately.

Also added a 'status' label with 'succeeded' and 'failed' values to correlate with a similar label available on the upstream pipelineruns duration metric, in case we see patterns where gaps vary based on failures in the underlying containers.

@ramessesii2 @Roming22 when we start talking about SLAs for underlying tekton, based on the performance WG experience, I believe we should exclude the time taken in underlying pods/containers (which pipelinerun duration includes for example), and focus on how quickly for example tekton processes things in between the containers.

For example, if when looking at the gap histogram, if the number of samples in the "62500 millisecond" bucket is greater than the number of samples in the "12500 millisecond bucket", then it is taking tekton over 12.5 seconds in some cases to create a new taskrun after the preceding taskrun completes within a pipelinerun.  That speaks to the tekton controller possibly being bogged down / under duress, and we should conceivably investigate.

See https://issues.redhat.com/browse/PLNSRVCE-1443?focusedId=22949541&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22949541 for the breakdown of the buckets created by the upstream pipelinerun duration histogram

 