### PR TITLE
PLNSRVCE-1406,PLNSRVCE-1407: Craft more metrics around measuring the gaps between creation of tekton objects and starting of pod/containers

### DIFF
--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -18,8 +18,35 @@ package collector
 
 import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 )
+
+/*
+  Observed sequence from testing and tekton/k8s code examination:
+
+- taskrun created by external user or pipelinerun reconciler, and k8s sets the taskrun create timestap
+- on first reconcile event loop, taskrun ConditionSucceeded condition is intialized to pending and the startime is set
+- "prepare" will see if resolutionrequest is needed, and if so, error is returned to controller fw and requeue happens
+- otherwise, or on next reconcile event loop, volume claim templates / workspaces processed, params processed, and if no errors, pod create attempted
+- if error requeue
+- otherwise pod status converted to taskrun status, with conditions now updated and set running, controller then puts back on queue with requeueAfter(timeDuration)
+
+Now concurrent event streams from both Pod updates or TaskRun updates, or requeuesAfter(timeDuration) calling reconcile again, can update task run status and conditions
+
+On pods
+- create time stems from tekton creating
+- pod start time means kubelet has "accepted" per godoc for scheduling, but no image pulls have occurred, where
+using of "latest" for the tag means always pull per godoc, but use of a specific SHA means pull if not on local CRI-O / "node cache"
+
+So,
+- no real diff of worth between taskrun startime and its conditions
+- pod create vs. pod start time captures how long the external factor of the Kubelet agreeing the schedule the pod takes
+- pod start time vs. first container start captures how long to pull images and schedule the container
+- where as the upstream latency metric of the last transition time of the `corev1.PodScheduled` condition minus the pod create time
+is "perhaps" the sum of those two
+*/
 
 func calcuateScheduledDuration(created, started time.Time) float64 {
 	if created.IsZero() || started.IsZero() {
@@ -34,4 +61,49 @@ func calculateScheduledDurationPipelineRun(pipelineRun *v1beta1.PipelineRun) flo
 
 func calculateScheduledDurationTaskRun(taskrun *v1beta1.TaskRun) float64 {
 	return calcuateScheduledDuration(taskrun.CreationTimestamp.Time, taskrun.Status.StartTime.Time)
+}
+
+// this minimally captures any time the kubelet spends pulling container images for the pod
+func calculateTaskRunPodStartedToFirstContainerStartedDuration(pod *corev1.Pod) float64 {
+	if pod.Status.StartTime == nil || pod.Status.StartTime.IsZero() {
+		return 0
+	}
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return 0
+	}
+	var firstTime *metav1.Time
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Running != nil && !cs.State.Running.StartedAt.IsZero() {
+			if firstTime == nil {
+				firstTime = &cs.State.Running.StartedAt
+				continue
+			}
+			if cs.State.Running.StartedAt.Before(firstTime) {
+				firstTime = &cs.State.Running.StartedAt
+				continue
+			}
+		}
+		if cs.State.Terminated != nil && !cs.State.Terminated.StartedAt.IsZero() {
+			if firstTime == nil {
+				firstTime = &cs.State.Terminated.StartedAt
+				continue
+			}
+			if cs.State.Terminated.StartedAt.Before(firstTime) {
+				firstTime = &cs.State.Terminated.StartedAt
+				continue
+			}
+		}
+	}
+	if firstTime == nil {
+		return 0
+	}
+	return float64(firstTime.Time.Sub(pod.Status.StartTime.Time).Milliseconds())
+}
+
+// this captures how long it takes for the kubelet to accept the pod after the pod is created
+func calculateTaskRunPodCreatedToKubeletAcceptsAndStartTimeSetDuration(pod *corev1.Pod) float64 {
+	if pod.Status.StartTime == nil || pod.Status.StartTime.IsZero() {
+		return 0
+	}
+	return float64(pod.Status.StartTime.Time.Sub(pod.CreationTimestamp.Time).Milliseconds())
 }

--- a/collector/metrics_test.go
+++ b/collector/metrics_test.go
@@ -26,117 +26,296 @@ import (
 )
 
 func TestCalculatePipelineRunScheduledDuration(t *testing.T) {
-	// Create mock PipelineRuns data
-	mockPipelineRuns := []*v1beta1.PipelineRun{
+	now := time.Now()
+	for _, tc := range []struct {
+		expectedAmt float64
+		pr          *v1beta1.PipelineRun
+	}{
 		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "test-pipelinerun-1",
-				Namespace:         "test-namespace",
-				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
-			},
-			Status: v1beta1.PipelineRunStatus{
-				Status: duckv1.Status{
-					ObservedGeneration: 0,
-					Conditions: duckv1.Conditions{{
-						Type:   "Succeeded",
-						Status: corev1.ConditionTrue,
-					}},
-					Annotations: nil,
+			expectedAmt: 5,
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pipelinerun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
 				},
-				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
-					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 0,
+						Conditions: duckv1.Conditions{{
+							Type:   "Succeeded",
+							Status: corev1.ConditionTrue,
+						}},
+						Annotations: nil,
+					},
+					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: now.Add(5 * time.Second)},
+						CompletionTime: &metav1.Time{Time: now.Add(10 * time.Second)},
+					},
 				},
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "test-pipelinerun-1",
-				Namespace:         "test-namespace",
-				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
-			},
-			Status: v1beta1.PipelineRunStatus{
-				Status: duckv1.Status{
-					ObservedGeneration: 0,
-					Conditions: duckv1.Conditions{{
-						Type:   "Failed",
-						Status: corev1.ConditionTrue,
-					}},
-					Annotations: nil,
+			expectedAmt: 5,
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pipelinerun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
 				},
-				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
-					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 0,
+						Conditions: duckv1.Conditions{{
+							Type:   "Failed",
+							Status: corev1.ConditionTrue,
+						}},
+						Annotations: nil,
+					},
+					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: now.Add(5 * time.Second)},
+						CompletionTime: &metav1.Time{Time: now.Add(10 * time.Second)},
+					},
 				},
 			},
 		},
-	}
-
-	for _, pr := range mockPipelineRuns {
-		want := 5
-		got := int(calculateScheduledDurationPipelineRun(pr))
-
-		if got != want {
-			t.Errorf("Scheduled Duration is not as expected. Got %d, expected %d", got, want)
+	} {
+		got := calculateScheduledDurationPipelineRun(tc.pr)
+		if got != tc.expectedAmt {
+			t.Errorf("Scheduled Duration is not as expected. Got %v, expected %v", got, tc.expectedAmt)
 		}
 	}
-
 }
 
 func TestCalculateTaskRunScheduledDuration(t *testing.T) {
-	// Create mock TaskRuns data
-	mockTaskRuns := []*v1beta1.TaskRun{
+	now := time.Now()
+	for _, tc := range []struct {
+		expectedAmt float64
+		tr          *v1beta1.TaskRun
+	}{
 		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "test-taskrun-1",
-				Namespace:         "test-namespace",
-				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1.Status{
-					ObservedGeneration: 0,
-					Conditions: duckv1.Conditions{{
-						Type:   "Succeeded",
-						Status: corev1.ConditionTrue,
-					}},
-					Annotations: nil,
+			expectedAmt: 5,
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
 				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
-					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 0,
+						Conditions: duckv1.Conditions{{
+							Type:   "Succeeded",
+							Status: corev1.ConditionTrue,
+						}},
+						Annotations: nil,
+					},
+					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+						StartTime:      &metav1.Time{Time: now.Add(5 * time.Second)},
+						CompletionTime: &metav1.Time{Time: now.Add(10 * time.Second)},
+					},
 				},
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "test-taskrun-1",
-				Namespace:         "test-namespace",
-				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1.Status{
-					ObservedGeneration: 0,
-					Conditions: duckv1.Conditions{{
-						Type:   "Failed",
-						Status: corev1.ConditionTrue,
-					}},
-					Annotations: nil,
+			expectedAmt: 5,
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
 				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
-					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 0,
+						Conditions: duckv1.Conditions{{
+							Type:   "Failed",
+							Status: corev1.ConditionTrue,
+						}},
+						Annotations: nil,
+					},
+					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+						StartTime:      &metav1.Time{Time: now.Add(5 * time.Second)},
+						CompletionTime: &metav1.Time{Time: now.Add(10 * time.Second)},
+					},
 				},
 			},
 		},
-	}
-
-	for _, tr := range mockTaskRuns {
-		want := 5
-		got := int(calculateScheduledDurationTaskRun(tr))
-
-		if got != want {
-			t.Errorf("Scheduled Duration is not as expected. Got %d, expected %d", got, want)
+	} {
+		got := calculateScheduledDurationTaskRun(tc.tr)
+		if got != tc.expectedAmt {
+			t.Errorf("Scheduled Duration is not as expected. Got %v, expected %v", got, tc.expectedAmt)
 		}
 	}
+}
 
+func TestCalculateTaskRunPodStartedToFirstContainerStartedDuration(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		expectedAmt float64
+		pod         *corev1.Pod
+	}{
+		{
+			expectedAmt: 0,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
+				},
+			},
+		},
+		{
+			expectedAmt: 0,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
+				},
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: now.Add(3 * time.Second)}},
+			},
+		},
+		{
+			expectedAmt: 0,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
+				},
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: now.Add(3 * time.Second)}},
+			},
+		},
+		{
+			expectedAmt: 2000,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
+				},
+				Status: corev1.PodStatus{
+					StartTime: &metav1.Time{Time: now.Add(3 * time.Second)},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: now.Add(5 * time.Second)}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			expectedAmt: 2000,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
+				},
+				Status: corev1.PodStatus{
+					StartTime: &metav1.Time{Time: now.Add(3 * time.Second)},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{StartedAt: metav1.Time{Time: now.Add(5 * time.Second)}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			expectedAmt: 2000,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
+				},
+				Status: corev1.PodStatus{
+					StartTime: &metav1.Time{Time: now.Add(3 * time.Second)},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: now.Add(6 * time.Second)}},
+							},
+						},
+						{
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{StartedAt: metav1.Time{Time: now.Add(5 * time.Second)}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			expectedAmt: 2000,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
+				},
+				Status: corev1.PodStatus{
+					StartTime: &metav1.Time{Time: now.Add(3 * time.Second)},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: now.Add(5 * time.Second)}},
+							},
+						},
+						{
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{StartedAt: metav1.Time{Time: now.Add(6 * time.Second)}},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		got := calculateTaskRunPodStartedToFirstContainerStartedDuration(tc.pod)
+		if got != tc.expectedAmt {
+			t.Errorf("expected %v but got %v", tc.expectedAmt, got)
+		}
+	}
+}
+
+func TestCalculateTaskRunPodCreatedToKubeletAcceptsAndStartTimeSetDuration(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		expectedAmt float64
+		pod         *corev1.Pod
+	}{
+		{
+			expectedAmt: 3000,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
+				},
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: now.Add(3 * time.Second)}},
+			},
+		},
+		{
+			expectedAmt: 0,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-taskrun-1",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(now),
+				},
+			},
+		},
+	} {
+		got := calculateTaskRunPodCreatedToKubeletAcceptsAndStartTimeSetDuration(tc.pod)
+		if got != tc.expectedAmt {
+			t.Errorf("expected %v but got %v", tc.expectedAmt, got)
+		}
+	}
 }

--- a/collector/pipelinerun_test.go
+++ b/collector/pipelinerun_test.go
@@ -158,8 +158,10 @@ func TestResetPVCStats(t *testing.T) {
 	validateGaugeVec(t, pvcReconciler.prCollector.pvcThrottle, label, float64(1))
 }
 
-func TestStartTimeEventFilter_Update(t *testing.T) {
-	filter := &startTimeEventFilter{}
+func TestPipelineRunStartTimeEventFilter_Update(t *testing.T) {
+	filter := &startTimeEventFilter{
+		metric: NewPipelineRunScheduledMetric(),
+	}
 	for _, tc := range []struct {
 		name       string
 		oldPR      *v1beta1.PipelineRun
@@ -179,7 +181,6 @@ func TestStartTimeEventFilter_Update(t *testing.T) {
 					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{StartTime: &metav1.Time{}},
 				},
 			},
-			expectedRC: true,
 		},
 		{
 			name: "udpate after started",

--- a/collector/pod.go
+++ b/collector/pod.go
@@ -1,0 +1,151 @@
+package collector
+
+import (
+	"context"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type ReconcilePodCreateToKubeletLatency struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+}
+
+func (r *ReconcilePodCreateToKubeletLatency) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+func SetupPodCreateToKubeletDurationController(mgr ctrl.Manager) error {
+	filter := &createKubeletLatencyFilter{metric: NewPodCreateToKubeletDurationMetric()}
+	reconciler := &ReconcilePodCreateToKubeletLatency{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		eventRecorder: mgr.GetEventRecorderFor("MetricExporterStageOnePods"),
+	}
+	return ctrl.NewControllerManagedBy(mgr).For(&corev1.Pod{}).WithEventFilter(filter).Complete(reconciler)
+}
+
+type createKubeletLatencyFilter struct {
+	metric *prometheus.HistogramVec
+}
+
+func (f *createKubeletLatencyFilter) Create(event.CreateEvent) bool {
+	return false
+}
+
+func (f *createKubeletLatencyFilter) Generic(event.GenericEvent) bool {
+	return false
+}
+
+func (f *createKubeletLatencyFilter) Delete(event.DeleteEvent) bool {
+	return false
+}
+
+func (f *createKubeletLatencyFilter) Update(e event.UpdateEvent) bool {
+	oldpod, okold := e.ObjectOld.(*corev1.Pod)
+	newpod, oknew := e.ObjectNew.(*corev1.Pod)
+	if okold && oknew {
+		if oldpod.Status.StartTime == nil && newpod.Status.StartTime != nil {
+			labels := map[string]string{NS_LABEL: newpod.Namespace, TASK_NAME_LABEL: taskRef(newpod.Labels)}
+			f.metric.With(labels).Observe(calculateTaskRunPodCreatedToKubeletAcceptsAndStartTimeSetDuration(newpod))
+			return false
+		}
+	}
+	return false
+}
+
+type ReconcilePodKubeletToContainerLatency struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+}
+
+func (r *ReconcilePodKubeletToContainerLatency) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+func SetupPodKubeletToContainerStartDurationController(mgr ctrl.Manager) error {
+	filter := &kubeletContainerLatencyFilter{metric: NewPodKubeletToContainerStartDurationMetric()}
+	reconciler := &ReconcilePodKubeletToContainerLatency{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		eventRecorder: mgr.GetEventRecorderFor("MetricExporterStageTwoPods"),
+	}
+	return ctrl.NewControllerManagedBy(mgr).For(&corev1.Pod{}).WithEventFilter(filter).Complete(reconciler)
+}
+
+type PodKubeletToContainerLatencyCollector struct {
+	podStartFirstContainerStartCollector *prometheus.HistogramVec
+}
+
+type kubeletContainerLatencyFilter struct {
+	metric *prometheus.HistogramVec
+}
+
+func (f *kubeletContainerLatencyFilter) Create(event.CreateEvent) bool {
+	return false
+}
+
+func (f *kubeletContainerLatencyFilter) Generic(event.GenericEvent) bool {
+	return false
+}
+
+func (f *kubeletContainerLatencyFilter) Delete(event.DeleteEvent) bool {
+	return false
+}
+
+func (f *kubeletContainerLatencyFilter) Update(e event.UpdateEvent) bool {
+	oldpod, okold := e.ObjectOld.(*corev1.Pod)
+	newpod, oknew := e.ObjectNew.(*corev1.Pod)
+	if okold && oknew {
+		labels := map[string]string{NS_LABEL: newpod.Namespace, TASK_NAME_LABEL: taskRef(newpod.Labels)}
+
+		if oldpod.Status.StartTime == nil && newpod.Status.StartTime == nil {
+			return false
+		}
+		if len(oldpod.Status.ContainerStatuses) == 0 && len(newpod.Status.ContainerStatuses) != 0 {
+			// see if any of the new container statuses have a start time
+			for _, cs := range newpod.Status.ContainerStatuses {
+				if cs.State.Terminated != nil && !cs.State.Terminated.StartedAt.IsZero() {
+					f.metric.With(labels).Observe(calculateTaskRunPodStartedToFirstContainerStartedDuration(newpod))
+					return false
+				}
+				if cs.State.Running != nil && !cs.State.Running.StartedAt.IsZero() {
+					f.metric.With(labels).Observe(calculateTaskRunPodStartedToFirstContainerStartedDuration(newpod))
+					return false
+				}
+			}
+		}
+		if len(oldpod.Status.ContainerStatuses) != 0 && len(newpod.Status.ContainerStatuses) != 0 {
+			for _, cs := range oldpod.Status.ContainerStatuses {
+				// if old already has a container start, then quit
+				if cs.State.Terminated != nil && !cs.State.Terminated.StartedAt.IsZero() {
+					return false
+				}
+				// if old already has a container start, then quit
+				if cs.State.Running != nil && !cs.State.Running.StartedAt.IsZero() {
+					return false
+				}
+			}
+			// if old had container statuses but no start times, then let's see if new has start times
+			for _, cs := range newpod.Status.ContainerStatuses {
+				if cs.State.Terminated != nil && !cs.State.Terminated.StartedAt.IsZero() {
+					f.metric.With(labels).Observe(calculateTaskRunPodStartedToFirstContainerStartedDuration(newpod))
+					return false
+				}
+				if cs.State.Running != nil && !cs.State.Running.StartedAt.IsZero() {
+					f.metric.With(labels).Observe(calculateTaskRunPodStartedToFirstContainerStartedDuration(newpod))
+					return false
+				}
+			}
+		}
+	}
+	return false
+}

--- a/collector/pod_test.go
+++ b/collector/pod_test.go
@@ -1,0 +1,197 @@
+package collector
+
+import (
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"testing"
+	"time"
+)
+
+func TestCreateKubeletLatencyFilter_Update(t *testing.T) {
+	filter := &createKubeletLatencyFilter{
+		metric: NewPodCreateToKubeletDurationMetric(),
+	}
+	for _, tc := range []struct {
+		name           string
+		oldPod         *corev1.Pod
+		newPod         *corev1.Pod
+		expectedRC     bool
+		expectedMetric bool
+	}{
+		{
+			name:   "both start times nil",
+			oldPod: &corev1.Pod{},
+			newPod: &corev1.Pod{},
+		},
+		{
+			name:           "only new start time set",
+			expectedMetric: true,
+			oldPod:         &corev1.Pod{},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: time.Now()}},
+			},
+		},
+		{
+			name: "both start times set",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: time.Now()}},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: time.Now()}},
+			},
+		},
+	} {
+		ev := event.UpdateEvent{
+			ObjectOld: tc.oldPod,
+			ObjectNew: tc.newPod,
+		}
+		rc := filter.Update(ev)
+		if rc != tc.expectedRC {
+			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
+		}
+		if tc.expectedMetric {
+			validateHistogramVec(t, filter.metric, prometheus.Labels{NS_LABEL: tc.newPod.Namespace, TASK_NAME_LABEL: taskRef(tc.newPod.Labels)}, false)
+		}
+	}
+}
+
+func TestKubeletContainerLatencyFilter_Update(t *testing.T) {
+	filter := &kubeletContainerLatencyFilter{
+		metric: NewPodKubeletToContainerStartDurationMetric(),
+	}
+	for _, tc := range []struct {
+		name           string
+		oldPod         *corev1.Pod
+		newPod         *corev1.Pod
+		expectedRC     bool
+		expectedMetric bool
+	}{
+		{
+			name:   "both start times nil",
+			oldPod: &corev1.Pod{},
+			newPod: &corev1.Pod{},
+		},
+		{
+			name: "both start times set, no container status",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: time.Now()}},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: time.Now()}},
+			},
+		},
+		{
+			name: "both start times set, no container status",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: time.Now()}},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: time.Now()}},
+			},
+		},
+		{
+			name: "both start times set, new only container running state",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: time.Now()}},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					StartTime: &metav1.Time{Time: time.Now()},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{
+									StartedAt: metav1.NewTime(time.Now()),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "both start times set, new only container terminated state",
+			expectedMetric: true,
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{StartTime: &metav1.Time{Time: time.Now()}},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					StartTime: &metav1.Time{Time: time.Now()},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									StartedAt: metav1.NewTime(time.Now()),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "both start times set, old container array set, not status, new container terminated state",
+			expectedMetric: true,
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					StartTime:         &metav1.Time{Time: time.Now()},
+					ContainerStatuses: []corev1.ContainerStatus{},
+				},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					StartTime: &metav1.Time{Time: time.Now()},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									StartedAt: metav1.NewTime(time.Now()),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "both start times set, old container array set, not status, new container running state",
+			expectedMetric: true,
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					StartTime:         &metav1.Time{Time: time.Now()},
+					ContainerStatuses: []corev1.ContainerStatus{},
+				},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					StartTime: &metav1.Time{Time: time.Now()},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{
+									StartedAt: metav1.NewTime(time.Now()),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		ev := event.UpdateEvent{
+			ObjectOld: tc.oldPod,
+			ObjectNew: tc.newPod,
+		}
+		rc := filter.Update(ev)
+		if rc != tc.expectedRC {
+			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
+		}
+		if tc.expectedMetric {
+			validateHistogramVec(t, filter.metric, prometheus.Labels{NS_LABEL: tc.newPod.Namespace, TASK_NAME_LABEL: taskRef(tc.newPod.Labels)}, false)
+		}
+	}
+}

--- a/collector/taskrun_test.go
+++ b/collector/taskrun_test.go
@@ -1,0 +1,59 @@
+package collector
+
+import (
+	"fmt"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"testing"
+)
+
+func TestTaskRunStartTimeEventFilter_Update(t *testing.T) {
+	filter := &trStartTimeEventFilter{
+		metric: NewTaskRunScheduledMetric(),
+	}
+	for _, tc := range []struct {
+		name       string
+		oldTR      *v1beta1.TaskRun
+		newTR      *v1beta1.TaskRun
+		expectedRC bool
+	}{
+		{
+			name:  "not started",
+			oldTR: &v1beta1.TaskRun{},
+			newTR: &v1beta1.TaskRun{},
+		},
+		{
+			name:  "just started",
+			oldTR: &v1beta1.TaskRun{},
+			newTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					TaskRunStatusFields: v1beta1.TaskRunStatusFields{StartTime: &metav1.Time{}},
+				},
+			},
+		},
+		{
+			name: "udpate after started",
+			oldTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					TaskRunStatusFields: v1beta1.TaskRunStatusFields{StartTime: &metav1.Time{}},
+				},
+			},
+			newTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					TaskRunStatusFields: v1beta1.TaskRunStatusFields{StartTime: &metav1.Time{}},
+				},
+			},
+		},
+	} {
+		ev := event.UpdateEvent{
+			ObjectOld: tc.oldTR,
+			ObjectNew: tc.newTR,
+		}
+		rc := filter.Update(ev)
+		if rc != tc.expectedRC {
+			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
+		}
+	}
+
+}

--- a/docs/metrics-specification.md
+++ b/docs/metrics-specification.md
@@ -17,20 +17,20 @@ _Data Type:_ Gauge
 _Description:_ The number of PipelineRuns marked failed because required PVCs could not be created.
 
 _**PipelineRun Scheduling Duration:**_  
-The duration of time in seconds taken for a PipelineRun to be scheduled, calculated as the difference between the creation timestamp and the start time of the PipelineRun.
+The duration of time in seconds taken for a PipelineRun to be "scheduled", meaning it has been received by the Tekton controller.  It is calculated as the difference between the creation timestamp and the start time of the PipelineRun, where the start time is set by the Tekton controller on the initial event received for the creation of the PipelineRun.  It is a good indication of how quickly the API server sends create events to the Tekton controller.
 
-_Metric Name:_ pipelinerun_scheduling_duration  
-_Labels:_ Minimally a `namespace` label.  If the `ENABLE_PIPELINERUN_SCHEDULED_DURATION_PIPELINENAME_LABEL` environment variable is set to `true` on the exporter deployment, the `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.
+_Metric Name:_ pipelinerun_duration_scheduled_seconds
+_Labels:_ a `namespace` label and the `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.
 _Data Type:_ Histogram
-_Description:_ The time taken in seconds for a PipelineRun to be scheduled.
+_Description:_ The time taken in seconds for a PipelineRun to be "scheduled", meaning it has been received by the Tekton controller.
 
 _**TaskRun Scheduling Duration:**_  
-The duration of time in seconds taken for a TaskRun to be scheduled, calculated as the difference between the creation timestamp and the start time of the TaskRun.
+The duration of time in seconds taken for a TaskRun to be "scheduled", meaning it has been received by the Tekton controller.  It is calculated as the difference between the creation timestamp and the start time of the TaskRun, where the start time is set by the Tekton controller on the initial event received for the creation of the TaskRun.  It is a good indication of how quickly the API server sends create events to the Tekton controller.
 
-_Metric Name:_ taskrunrun_scheduling_duration  
-_Labels:_ Minimally a `namespace` label.  If the `ENABLE_TASKRUN_SCHEDULED_DURATION_TASKNAME_LABEL` environment variable is set to `true` on the exporter deployment, the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
+_Metric Name:_ taskrun_duration_scheduled_seconds
+_Labels:_ a `namespace` label and the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
 _Data Type:_ Histogram
-_Description:_ The time taken in seconds for a TaskRun to be scheduled.
+_Description:_ The time taken in seconds for a TaskRun to be "scheduled", meaning it has been received by the Tekton controller.
 
 
 _**Scheduling Duration of different TaskRuns with a PipelineRun:**_
@@ -40,6 +40,24 @@ _Metric Name:_ pipelinerun_gap_between_taskruns_milliseconds
 _Labels:_ Minimally a `namespace` label.  If the `ENABLE_GAP_METRIC_ADDITIONAL_LABELS` environment variable is set to `true` on the exporter deployment, the `pipelinename`, `completed`, and `upcoming` labels are set.  The `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.  The `completed` label is set either the Pipeline name if we are dealing with the first TaskRun, or the name of the latest Task for the TaskRun to be completed.  The `upcoming` label is set to the name of the Task of the TaskRun that is created but not yet complete.
 _Data Type_: Histogram
 _Description_: The taken between TaskRuns within a PipelineRun
+
+_**Scheduling Duration that a TaskRun Pod is recognized by the Kubelet:**_
+The time taken in milliseconds between the creation of a Pod, where the Pod start time is set once the kubelet has acknowledged the pod, but has not yet pulled its images.
+
+
+_Metric Name:_ taskrun_pod_duration_kubelet_acknowledged_milliseconds
+_Labels:_ a `namespace` label and the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
+_Data Type_: Histogram
+_Description_: Duration in milliseconds between the pod creation time and pod start time
+
+_**Scheduling Duration that a TaskRun Pod's images are pulled by the Kubelet and the Pod is started:**_
+The time taken in milliseconds between the pod start time and the first container to start. This should include any overhead to pull container images, plus any kubelet to linux scheduling overhead.
+
+
+_Metric Name:_ taskrun_pod_duration_kubelet_acknowledged_milliseconds
+_Labels:_ a `namespace` label and the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
+_Data Type_: Histogram
+_Description_: Duration in milliseconds between the pod start time and the first container to start.
 
 
 ### Metrics Format:


### PR DESCRIPTION
So in working the wait count and wait times for task/pipeline resolution, I ended up seeing again the upstream pod latency metrics, which is an odd calculation of 

  the last transition time of the `corev1.PodScheduled` condition minus the pod create time

So after a few passes at the tekton reconcile loops and k8s godoc around some of the pod status fields, I extrapolated this event sequencing:

```
  Observed sequence from testing and tekton/k8s code examination:

- taskrun created by external user or pipelinerun reconciler, and k8s sets the taskrun create timestap
- on first reconcile event loop, taskrun ConditionSucceeded condition is intialized to pending and the startime is set
- "prepare" will see if resolutionrequest is needed, and if so, error is returned to controller fw and requeue happens
- otherwise, or on next reconcile event loop, volume claim templates / workspaces processed, params processed, and if no errors, pod create attempted
- if error requeue
- otherwise pod status converted to taskrun status, with conditions now updated and set running, controller then puts back on queue with requeueAfter(timeDuration)

Now concurrent event streams from both Pod updates or TaskRun updates, or requeuesAfter(timeDuration) calling reconcile again, can update task run status and conditions

On pods
- create time stems from tekton creating
- pod start time means kubelet has "accepted" per godoc for scheduling, but no image pulls have occurred, where
using of "latest" for the tag means always pull per godoc, but use of a specific SHA means pull if not on local CRI-O / "node cache"

So,
- no real diff of worth between taskrun startime and its conditions
- pod create vs. pod start time captures how long the external factor of the Kubelet agreeing the schedule the pod takes
- pod start time vs. first container start captures how long to pull images and schedule the container
- where as the upstream latency metric of the last transition time of the `corev1.PodScheduled` condition minus the pod create time
is "perhaps" the sum of those two
```

With that flow in mind:
     - add 2 new metrics to help capture gaps between create timestamps, pod start timestamps, and container start containers
     - add more unit tests, unit test fixes
    - simplify obtaining of task,pipeline reference
    - bump counters from filters 
    - clarify some metric descriptions/help
