### PR TITLE
PLNSRVCE-1406:  add metrics for wait time on pipelne/task reference resolution

### DIFF
--- a/collector/controller.go
+++ b/collector/controller.go
@@ -105,5 +105,15 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	err = SetupTaskReferenceWaitTimeController(mgr)
+	if err != nil {
+		return nil, err
+	}
+
+	err = SetupPipelineReferenceWaitTimeController(mgr)
+	if err != nil {
+		return nil, err
+	}
 	return mgr, nil
 }

--- a/collector/pipeline_reference_wait_time.go
+++ b/collector/pipeline_reference_wait_time.go
@@ -1,0 +1,130 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func SetupPipelineReferenceWaitTimeController(mgr ctrl.Manager) error {
+	reconciler := &ReconcilePipelineReferenceWaitTime{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		eventRecorder: mgr.GetEventRecorderFor("MetricExporterWaitPipelineRunPipelineResolution"),
+	}
+	waitMetric := NewPipelineReferenceWaitTimeMetric()
+	metrics.Registry.MustRegister(waitMetric)
+	return ctrl.NewControllerManagedBy(mgr).For(&v1beta1.PipelineRun{}).WithEventFilter(&pipelineRefWaitTimeFilter{waitDuration: waitMetric}).Complete(reconciler)
+}
+
+func NewPipelineReferenceWaitTimeMetric() *prometheus.HistogramVec {
+	labelNames := []string{NS_LABEL, PIPELINE_NAME_LABEL}
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "pipelinerun_pipeline_resolution_wait_milliseconds",
+		Help:    "Duration in milliseconds for a resolution request for a pipeline reference needed by a pipelinerun to be recognized as complete by the pipelinerun reconciler in the tekton controller. ",
+		Buckets: prometheus.ExponentialBuckets(float64(100), float64(5), 6),
+	}, labelNames)
+
+}
+
+type ReconcilePipelineReferenceWaitTime struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+}
+
+type pipelineRefWaitTimeFilter struct {
+	waitDuration *prometheus.HistogramVec
+	// so knative/tekton allows for updates to a conditions last transition time without changing the reason of the condition,
+	// but if the condition has not changed,  it leaves the transition time alone.  The tekton code right now has a constant
+	// message so the condition should not change on any multiple calls.  That said, we'll add a log that captures that, and
+	// if it is occuring, we'll need to track the original transition time either via state in this filter, or as a label/annotation
+	// on the pipelinerun
+}
+
+func (f *pipelineRefWaitTimeFilter) Create(event.CreateEvent) bool {
+	return false
+}
+
+func (f *pipelineRefWaitTimeFilter) Generic(event.GenericEvent) bool {
+	return false
+}
+
+func (f *pipelineRefWaitTimeFilter) Delete(event.DeleteEvent) bool {
+	return false
+}
+
+func (f *pipelineRefWaitTimeFilter) Update(e event.UpdateEvent) bool {
+	//TODO remember, keep track of when pipeline-service and RHTAP starts moving from v1beta1 to v1
+	oldPR, okold := e.ObjectOld.(*v1beta1.PipelineRun)
+	newPR, oknew := e.ObjectNew.(*v1beta1.PipelineRun)
+	if okold && oknew {
+		newSucceedCondition := newPR.Status.GetCondition(apis.ConditionSucceeded)
+		if newSucceedCondition == nil {
+			return false
+		}
+		if !oldPR.IsDone() && newPR.IsDone() {
+			// if we did not use some sort of resolve, set metric to 0
+			if newPR.Spec.PipelineRef == nil {
+				labels := map[string]string{NS_LABEL: newPR.Namespace, PIPELINE_NAME_LABEL: pipelineRef(newPR.Labels)}
+				f.waitDuration.With(labels).Observe(float64(0))
+			}
+		}
+		if newPR.IsDone() {
+			return false
+		}
+		oldSucceedCondtition := oldPR.Status.GetCondition(apis.ConditionSucceeded)
+		if oldSucceedCondtition == nil {
+			return false
+		}
+		oldReason := oldSucceedCondtition.Reason
+		newReason := newSucceedCondition.Reason
+		// wrt direct string reference, waiting for tag/release with constant moved to the api package
+		if oldReason == "ResolvingPipelineRef" && newReason != "ResolvingPipelineRef" {
+			labels := map[string]string{NS_LABEL: newPR.Namespace, PIPELINE_NAME_LABEL: pipelineRef(newPR.Labels)}
+			originalTime := oldSucceedCondtition.LastTransitionTime.Inner
+			f.waitDuration.With(labels).Observe(float64(newSucceedCondition.LastTransitionTime.Inner.Sub(originalTime.Time).Milliseconds()))
+			return false
+		}
+		// wrt direct string reference, waiting for tag/release with constant moved to the api package;
+		// otherwise, per current examination of Tekton code, we should not see any updates in transition time
+		// if multiple SetCondition calls are made, as the Reason/Message fields should not change for resolving refs,
+		// but if that changes, this log should be a warning
+		if oldReason == "ResolvingPipelineRef" && newReason == "ResolvingPipelineRef" &&
+			!oldSucceedCondtition.LastTransitionTime.Inner.Equal(&newSucceedCondition.LastTransitionTime.Inner) {
+			ctrl.Log.Info(fmt.Sprintf("WARNING resolving condition for pipelinerun %s:%s changed from %#v to %#v",
+				newPR.Namespace,
+				newPR.Name,
+				oldSucceedCondtition,
+				newSucceedCondition))
+			return false
+		}
+	}
+	return false
+}
+
+func (r *ReconcilePipelineReferenceWaitTime) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+func pipelineRef(labels map[string]string) string {
+	p, _ := labels[pipeline.PipelineLabelKey]
+	pr, _ := labels[pipeline.PipelineRunLabelKey]
+	switch {
+	case len(p) > 0:
+		return p
+	case len(pr) > 0:
+		return pr
+	}
+	return ""
+}

--- a/collector/pipeline_reference_wait_time_test.go
+++ b/collector/pipeline_reference_wait_time_test.go
@@ -1,0 +1,155 @@
+package collector
+
+import (
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"testing"
+	"time"
+)
+
+func TestPipelineRefWaitTimeFilter_Update(t *testing.T) {
+	filter := &pipelineRefWaitTimeFilter{waitDuration: NewPipelineReferenceWaitTimeMetric()}
+	now := time.Now()
+	for _, tc := range []struct {
+		name                  string
+		oldPR                 *v1beta1.PipelineRun
+		newPR                 *v1beta1.PipelineRun
+		expectedRC            bool
+		expectedNonZeroMetric bool
+	}{
+		{
+			name:  "not started",
+			oldPR: &v1beta1.PipelineRun{},
+			newPR: &v1beta1.PipelineRun{},
+		},
+		{
+			name:  "done",
+			oldPR: &v1beta1.PipelineRun{},
+			newPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "both running, same transition time",
+			oldPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             "ResolvingPipelineRef", // waiting for tag/release with constant moved to the api package
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
+						},
+					}},
+				},
+			},
+			newPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             "ResolvingPipelineRef", // waiting for tag/release with constant moved to the api package
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "both running, diff transition time",
+			oldPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             "ResolvingPipelineRef", // waiting for tag/release with constant moved to the api package
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
+						},
+					}},
+				},
+			},
+			newPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             "ResolvingPipelineRef", // waiting for tag/release with constant moved to the api package
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now.Add(1 * time.Second))},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name:                  "wait over",
+			expectedNonZeroMetric: true,
+			oldPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             "ResolvingPipelineRef", // waiting for tag/release with constant moved to the api package
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
+						},
+					}},
+				},
+			},
+			newPR: &v1beta1.PipelineRun{
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             "ResolvingPipelineRef", // waiting for tag/release with constant moved to the api package
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now.Add(1 * time.Second))},
+						},
+					}},
+				},
+			},
+		},
+	} {
+		ev := event.UpdateEvent{
+			ObjectOld: tc.oldPR,
+			ObjectNew: tc.newPR,
+		}
+		rc := filter.Update(ev)
+		if rc != tc.expectedRC {
+			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
+		}
+		labels := prometheus.Labels{NS_LABEL: tc.newPR.Namespace, PIPELINE_NAME_LABEL: pipelineRef(tc.newPR.Labels)}
+		if tc.expectedNonZeroMetric {
+			validateHistogramVec(t, filter.waitDuration, labels, false)
+		} else {
+			observer, err := filter.waitDuration.GetMetricWith(labels)
+			assert.NoError(t, err)
+			assert.NotNil(t, observer)
+			histogram := observer.(prometheus.Histogram)
+			metric := &dto.Metric{}
+			histogram.Write(metric)
+			assert.NotNil(t, metric.Histogram)
+			assert.NotNil(t, metric.Histogram.SampleCount)
+			if tc.newPR.IsDone() {
+				assert.NotZero(t, metric.Histogram.SampleCount)
+			}
+		}
+	}
+}

--- a/collector/task_reference_wait_time.go
+++ b/collector/task_reference_wait_time.go
@@ -1,0 +1,125 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func SetupTaskReferenceWaitTimeController(mgr ctrl.Manager) error {
+	reconciler := &ReconcileTaskReferenceWaitTime{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		eventRecorder: mgr.GetEventRecorderFor("MetricExporterWaitTaskRunTaskResolution"),
+	}
+	waitMetric := NewTaskReferenceWaitTimeMetric()
+	metrics.Registry.MustRegister(waitMetric)
+	return ctrl.NewControllerManagedBy(mgr).For(&v1beta1.TaskRun{}).WithEventFilter(&taskRefWaitTimeFilter{waitDuration: waitMetric}).Complete(reconciler)
+}
+
+func NewTaskReferenceWaitTimeMetric() *prometheus.HistogramVec {
+	labelNames := []string{NS_LABEL, TASK_NAME_LABEL}
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "taskrun_task_resolution_wait_milliseconds",
+		Help:    "Duration in milliseconds for a resolution request for a task reference needed by a taskrun to be recognized as complete by the taskrun reconciler in the tekton controller. ",
+		Buckets: prometheus.ExponentialBuckets(float64(100), float64(5), 6),
+	}, labelNames)
+
+}
+
+type ReconcileTaskReferenceWaitTime struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+}
+
+type taskRefWaitTimeFilter struct {
+	waitDuration *prometheus.HistogramVec
+	// so knative/tekton allows for updates to a conditions last transition time without changing the reason of the condition,
+	// but if the condition has not changed,  it leaves the transition time alone.  The tekton code right now has a constant
+	// message so the condition should not change on any multiple calls.  That said, we'll add a log that captures that, and
+	// if it is occuring, we'll need to track the original transition time either via state in this filter, or as a label/annotation
+	// on the taskrun
+}
+
+func (f *taskRefWaitTimeFilter) Create(event.CreateEvent) bool {
+	return false
+}
+
+func (f *taskRefWaitTimeFilter) Generic(event.GenericEvent) bool {
+	return false
+}
+
+func (f *taskRefWaitTimeFilter) Delete(event.DeleteEvent) bool {
+	return false
+}
+
+func (f *taskRefWaitTimeFilter) Update(e event.UpdateEvent) bool {
+	//TODO remember, keep track of when pipeline-service and RHTAP starts moving from v1beta1 to v1
+	oldTR, okold := e.ObjectOld.(*v1beta1.TaskRun)
+	newTR, oknew := e.ObjectNew.(*v1beta1.TaskRun)
+	if okold && oknew {
+		newSucceedCondition := newTR.Status.GetCondition(apis.ConditionSucceeded)
+		if newSucceedCondition == nil {
+			return false
+		}
+		if !oldTR.IsDone() && newTR.IsDone() {
+			// if we did not use some sort of resolve, set metric to 0
+			if newTR.Spec.TaskRef == nil {
+				labels := map[string]string{NS_LABEL: newTR.Namespace, TASK_NAME_LABEL: taskRef(newTR.Labels)}
+				f.waitDuration.With(labels).Observe(float64(0))
+			}
+			return false
+		}
+		if newTR.IsDone() {
+			return false
+		}
+		oldSucceedCondtition := oldTR.Status.GetCondition(apis.ConditionSucceeded)
+		if oldSucceedCondtition == nil {
+			return false
+		}
+		oldReason := oldSucceedCondtition.Reason
+		newReason := newSucceedCondition.Reason
+		if oldReason == v1beta1.TaskRunReasonResolvingTaskRef && newReason != v1beta1.TaskRunReasonResolvingTaskRef {
+			labels := map[string]string{NS_LABEL: newTR.Namespace, TASK_NAME_LABEL: taskRef(newTR.Labels)}
+			originalTime := oldSucceedCondtition.LastTransitionTime.Inner
+			f.waitDuration.With(labels).Observe(float64(newSucceedCondition.LastTransitionTime.Inner.Sub(originalTime.Time).Milliseconds()))
+			return false
+		}
+		// per current examination of Tekton code, we should not see any updates in transition time
+		// if multiple SetCondition calls are made, as the Reason/Message fields should not change for resolving refs,
+		// but if that changes, this log should be a warning
+		if oldReason == v1beta1.TaskRunReasonResolvingTaskRef && newReason == v1beta1.TaskRunReasonResolvingTaskRef &&
+			!oldSucceedCondtition.LastTransitionTime.Inner.Equal(&newSucceedCondition.LastTransitionTime.Inner) {
+			ctrl.Log.Info(fmt.Sprintf("WARNING resolving condition for taskrun %s:%s changed from %#v to %#v",
+				newTR.Namespace,
+				newTR.Name,
+				oldSucceedCondtition,
+				newSucceedCondition))
+			return false
+		}
+	}
+	return false
+}
+
+func (f *taskRefWaitTimeFilter) getKey(tr *v1beta1.TaskRun) string {
+	key := types.NamespacedName{
+		Namespace: tr.Namespace,
+		Name:      tr.Name,
+	}
+	return key.String()
+}
+
+func (r *ReconcileTaskReferenceWaitTime) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}

--- a/collector/task_reference_wait_time_test.go
+++ b/collector/task_reference_wait_time_test.go
@@ -1,0 +1,155 @@
+package collector
+
+import (
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"testing"
+	"time"
+)
+
+func TestTaskRefWaitTimeFilter_Update(t *testing.T) {
+	filter := &taskRefWaitTimeFilter{waitDuration: NewTaskReferenceWaitTimeMetric()}
+	now := time.Now()
+	for _, tc := range []struct {
+		name                  string
+		oldTR                 *v1beta1.TaskRun
+		newTR                 *v1beta1.TaskRun
+		expectedRC            bool
+		expectedNonZeroMetric bool
+	}{
+		{
+			name:  "not started",
+			oldTR: &v1beta1.TaskRun{},
+			newTR: &v1beta1.TaskRun{},
+		},
+		{
+			name:  "done",
+			oldTR: &v1beta1.TaskRun{},
+			newTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "both running, same transition time",
+			oldTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
+						},
+					}},
+				},
+			},
+			newTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "both running, diff transition time",
+			oldTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
+						},
+					}},
+				},
+			},
+			newTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now.Add(1 * time.Second))},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name:                  "wait over",
+			expectedNonZeroMetric: true,
+			oldTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
+						},
+					}},
+				},
+			},
+			newTR: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{
+						{
+							Type:               apis.ConditionSucceeded,
+							Status:             corev1.ConditionUnknown,
+							Reason:             v1beta1.TaskRunReasonRunning.String(),
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now.Add(1 * time.Second))},
+						},
+					}},
+				},
+			},
+		},
+	} {
+		ev := event.UpdateEvent{
+			ObjectOld: tc.oldTR,
+			ObjectNew: tc.newTR,
+		}
+		rc := filter.Update(ev)
+		if rc != tc.expectedRC {
+			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
+		}
+		labels := prometheus.Labels{NS_LABEL: tc.newTR.Namespace, TASK_NAME_LABEL: taskRef(tc.newTR.Labels)}
+		if tc.expectedNonZeroMetric {
+			validateHistogramVec(t, filter.waitDuration, labels, false)
+		} else {
+			observer, err := filter.waitDuration.GetMetricWith(labels)
+			assert.NoError(t, err)
+			assert.NotNil(t, observer)
+			histogram := observer.(prometheus.Histogram)
+			metric := &dto.Metric{}
+			histogram.Write(metric)
+			assert.NotNil(t, metric.Histogram)
+			assert.NotNil(t, metric.Histogram.SampleCount)
+			if tc.newTR.IsDone() {
+				assert.NotZero(t, metric.Histogram.SampleCount)
+			}
+		}
+	}
+}


### PR DESCRIPTION
So this PR adds the metrics for time spent waiting on bundle resolution for both any task or pipeline refs.

NOTE - this PR introduces a new file structure which hopefully simplifies by centralizing the bits needed for a given metric.

I envision in a separate PR restructuring the existing metrics to this new pattern.  Aside from centralizing related bits, it should better facilitate concurrent PRs from different folks in the future.