### PR TITLE
PLNSRVCE-1440: switch watches / default mode from v1beta1 to v1

### DIFF
--- a/collector/controller.go
+++ b/collector/controller.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"time"
 
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,13 +45,12 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 	if err := k8sscheme.AddToScheme(options.Scheme); err != nil {
 		return nil, err
 	}
-	//TODO v1 tekton API is coming soon
-	if err := pipelinev1beta1.AddToScheme(options.Scheme); err != nil {
+	if err := pipelinev1.AddToScheme(options.Scheme); err != nil {
 		return nil, err
 	}
 	options.NewCache = cache.BuilderWithOptions(cache.Options{
 		SelectorsByObject: cache.SelectorsByObject{
-			&pipelinev1beta1.PipelineRun{}: {},
+			&pipelinev1.PipelineRun{}: {},
 		}})
 
 	var mgr ctrl.Manager
@@ -120,6 +119,6 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return mgr, nil
 }

--- a/collector/pipeline_reference_wait_time.go
+++ b/collector/pipeline_reference_wait_time.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/apis"
@@ -24,7 +24,7 @@ func SetupPipelineReferenceWaitTimeController(mgr ctrl.Manager) error {
 	}
 	waitMetric := NewPipelineReferenceWaitTimeMetric()
 	metrics.Registry.MustRegister(waitMetric)
-	return ctrl.NewControllerManagedBy(mgr).For(&v1beta1.PipelineRun{}).WithEventFilter(&pipelineRefWaitTimeFilter{waitDuration: waitMetric}).Complete(reconciler)
+	return ctrl.NewControllerManagedBy(mgr).For(&v1.PipelineRun{}).WithEventFilter(&pipelineRefWaitTimeFilter{waitDuration: waitMetric}).Complete(reconciler)
 }
 
 func NewPipelineReferenceWaitTimeMetric() *prometheus.HistogramVec {
@@ -65,9 +65,8 @@ func (f *pipelineRefWaitTimeFilter) Delete(event.DeleteEvent) bool {
 }
 
 func (f *pipelineRefWaitTimeFilter) Update(e event.UpdateEvent) bool {
-	//TODO remember, keep track of when pipeline-service and RHTAP starts moving from v1beta1 to v1
-	oldPR, okold := e.ObjectOld.(*v1beta1.PipelineRun)
-	newPR, oknew := e.ObjectNew.(*v1beta1.PipelineRun)
+	oldPR, okold := e.ObjectOld.(*v1.PipelineRun)
+	newPR, oknew := e.ObjectNew.(*v1.PipelineRun)
 	if okold && oknew {
 		newSucceedCondition := newPR.Status.GetCondition(apis.ConditionSucceeded)
 		if newSucceedCondition == nil {

--- a/collector/pipeline_reference_wait_time_test.go
+++ b/collector/pipeline_reference_wait_time_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -20,21 +20,21 @@ func TestPipelineRefWaitTimeFilter_Update(t *testing.T) {
 	now := time.Now()
 	for _, tc := range []struct {
 		name                  string
-		oldPR                 *v1beta1.PipelineRun
-		newPR                 *v1beta1.PipelineRun
+		oldPR                 *v1.PipelineRun
+		newPR                 *v1.PipelineRun
 		expectedRC            bool
 		expectedNonZeroMetric bool
 	}{
 		{
 			name:  "not started",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{},
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{},
 		},
 		{
 			name:  "done",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:   apis.ConditionSucceeded,
@@ -46,8 +46,8 @@ func TestPipelineRefWaitTimeFilter_Update(t *testing.T) {
 		},
 		{
 			name: "both running, same transition time",
-			oldPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
@@ -58,8 +58,8 @@ func TestPipelineRefWaitTimeFilter_Update(t *testing.T) {
 					}},
 				},
 			},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
@@ -73,8 +73,8 @@ func TestPipelineRefWaitTimeFilter_Update(t *testing.T) {
 		},
 		{
 			name: "both running, diff transition time",
-			oldPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
@@ -85,8 +85,8 @@ func TestPipelineRefWaitTimeFilter_Update(t *testing.T) {
 					}},
 				},
 			},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
@@ -101,8 +101,8 @@ func TestPipelineRefWaitTimeFilter_Update(t *testing.T) {
 		{
 			name:                  "wait over",
 			expectedNonZeroMetric: true,
-			oldPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
@@ -113,8 +113,8 @@ func TestPipelineRefWaitTimeFilter_Update(t *testing.T) {
 					}},
 				},
 			},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,

--- a/collector/pipelinerun_create_to_start_time_test.go
+++ b/collector/pipelinerun_create_to_start_time_test.go
@@ -3,7 +3,7 @@ package collector
 import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,34 +19,34 @@ func TestPipelineRunStartTimeEventFilter_Update(t *testing.T) {
 	filter := &startTimeEventFilter{}
 	for _, tc := range []struct {
 		name       string
-		oldPR      *v1beta1.PipelineRun
-		newPR      *v1beta1.PipelineRun
+		oldPR      *v1.PipelineRun
+		newPR      *v1.PipelineRun
 		expectedRC bool
 	}{
 		{
 			name:  "not started",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{},
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{},
 		},
 		{
 			name:  "just started",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
-					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{StartTime: &metav1.Time{}},
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
+					PipelineRunStatusFields: v1.PipelineRunStatusFields{StartTime: &metav1.Time{}},
 				},
 			},
 		},
 		{
 			name: "udpate after started",
-			oldPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
-					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{StartTime: &metav1.Time{}},
+			oldPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
+					PipelineRunStatusFields: v1.PipelineRunStatusFields{StartTime: &metav1.Time{}},
 				},
 			},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
-					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{StartTime: &metav1.Time{}},
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
+					PipelineRunStatusFields: v1.PipelineRunStatusFields{StartTime: &metav1.Time{}},
 				},
 			},
 		},
@@ -66,7 +66,7 @@ func TestPipelineRunStartTimeEventFilter_Update(t *testing.T) {
 }
 
 func TestPipelineRunScheduleCollection(t *testing.T) {
-	mockPipelineRuns := []*v1beta1.PipelineRun{
+	mockPipelineRuns := []*v1.PipelineRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "test-pipelinerun-1",
@@ -74,7 +74,7 @@ func TestPipelineRunScheduleCollection(t *testing.T) {
 				UID:               types.UID("test-pipelinerun-1"),
 				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
 			},
-			Status: v1beta1.PipelineRunStatus{
+			Status: v1.PipelineRunStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 0,
 					Conditions: duckv1.Conditions{{
@@ -83,7 +83,7 @@ func TestPipelineRunScheduleCollection(t *testing.T) {
 					}},
 					Annotations: nil,
 				},
-				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
 					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
 					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
 				},
@@ -96,7 +96,7 @@ func TestPipelineRunScheduleCollection(t *testing.T) {
 				UID:               types.UID("test-pipelinerun-2"),
 				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
 			},
-			Status: v1beta1.PipelineRunStatus{
+			Status: v1.PipelineRunStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 0,
 					Conditions: duckv1.Conditions{{
@@ -105,7 +105,7 @@ func TestPipelineRunScheduleCollection(t *testing.T) {
 					}},
 					Annotations: nil,
 				},
-				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
 					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
 					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
 				},
@@ -118,7 +118,7 @@ func TestPipelineRunScheduleCollection(t *testing.T) {
 				UID:               types.UID("test-pipelinerun-3"),
 				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
 			},
-			Status: v1beta1.PipelineRunStatus{
+			Status: v1.PipelineRunStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 0,
 					Conditions: duckv1.Conditions{{
@@ -127,8 +127,8 @@ func TestPipelineRunScheduleCollection(t *testing.T) {
 					}},
 					Annotations: nil,
 				},
-				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-					ChildReferences: []v1beta1.ChildStatusReference{
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					ChildReferences: []v1.ChildStatusReference{
 						{
 							TypeMeta: runtime.TypeMeta{
 								Kind: "TaskRun",
@@ -162,17 +162,17 @@ func TestCalculatePipelineRunScheduledDuration(t *testing.T) {
 	now := time.Now()
 	for _, tc := range []struct {
 		expectedAmt float64
-		pr          *v1beta1.PipelineRun
+		pr          *v1.PipelineRun
 	}{
 		{
 			expectedAmt: 5,
-			pr: &v1beta1.PipelineRun{
+			pr: &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-pipelinerun-1",
 					Namespace:         "test-namespace",
 					CreationTimestamp: metav1.NewTime(now),
 				},
-				Status: v1beta1.PipelineRunStatus{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						ObservedGeneration: 0,
 						Conditions: duckv1.Conditions{{
@@ -181,7 +181,7 @@ func TestCalculatePipelineRunScheduledDuration(t *testing.T) {
 						}},
 						Annotations: nil,
 					},
-					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					PipelineRunStatusFields: v1.PipelineRunStatusFields{
 						StartTime:      &metav1.Time{Time: now.Add(5 * time.Second)},
 						CompletionTime: &metav1.Time{Time: now.Add(10 * time.Second)},
 					},
@@ -190,13 +190,13 @@ func TestCalculatePipelineRunScheduledDuration(t *testing.T) {
 		},
 		{
 			expectedAmt: 5,
-			pr: &v1beta1.PipelineRun{
+			pr: &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-pipelinerun-1",
 					Namespace:         "test-namespace",
 					CreationTimestamp: metav1.NewTime(now),
 				},
-				Status: v1beta1.PipelineRunStatus{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						ObservedGeneration: 0,
 						Conditions: duckv1.Conditions{{
@@ -205,7 +205,7 @@ func TestCalculatePipelineRunScheduledDuration(t *testing.T) {
 						}},
 						Annotations: nil,
 					},
-					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					PipelineRunStatusFields: v1.PipelineRunStatusFields{
 						StartTime:      &metav1.Time{Time: now.Add(5 * time.Second)},
 						CompletionTime: &metav1.Time{Time: now.Add(10 * time.Second)},
 					},

--- a/collector/pipelinerun_taskrun_complete_create_gaps_test.go
+++ b/collector/pipelinerun_taskrun_complete_create_gaps_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +26,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 	// to drive the gap metric, given its trickiness
 	objs := []client.Object{}
 	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
 	_ = v1beta1.AddToScheme(scheme)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 	gapReconciler := &ReconcilePipelineRunTaskRunGap{client: c, prCollector: NewPipelineRunTaskRunGapCollector()}
@@ -43,12 +45,20 @@ func TestPipelineRunGapCollection(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	for _, tr := range trs {
-		err = c.Create(ctx, &tr)
+	for _, trv1beta1 := range trs {
+		// mimic what the tekton conversion webhook will do
+		tr := &v1.TaskRun{}
+		err = trv1beta1.ConvertTo(ctx, tr)
+		assert.NoError(t, err)
+		err = c.Create(ctx, tr)
 		assert.NoError(t, err)
 	}
-	for _, pr := range prs {
-		err = c.Create(ctx, &pr)
+	for _, prv1beta1 := range prs {
+		// mimic what the tekton conversion webhook will do
+		pr := &v1.PipelineRun{}
+		err = prv1beta1.ConvertTo(ctx, pr)
+		assert.NoError(t, err)
+		err = c.Create(ctx, pr)
 		assert.NoError(t, err)
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -63,7 +73,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 
 	// then some additional unit tests were we build simpler pipelineruns/taskruns that capture paths
 	// related to completion times not being set
-	mockTaskRuns := []*v1beta1.TaskRun{
+	mockTaskRuns := []*v1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "test-taskrun-1",
@@ -71,7 +81,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 				UID:               types.UID("test-taskrun-1"),
 				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
 			},
-			Status: v1beta1.TaskRunStatus{
+			Status: v1.TaskRunStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 0,
 					Conditions: duckv1.Conditions{{
@@ -80,7 +90,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 					}},
 					Annotations: nil,
 				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
 					StartTime: &metav1.Time{Time: time.Now().UTC()},
 				},
 			},
@@ -92,7 +102,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 				UID:               types.UID("test-taskrun-2"),
 				CreationTimestamp: metav1.NewTime(time.Now().UTC().Add(5 * time.Second)),
 			},
-			Status: v1beta1.TaskRunStatus{
+			Status: v1.TaskRunStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 0,
 					Conditions: duckv1.Conditions{{
@@ -101,7 +111,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 					}},
 					Annotations: nil,
 				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
 					StartTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
 				},
 			},
@@ -113,7 +123,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 				UID:               types.UID("test-taskrun-3"),
 				CreationTimestamp: metav1.NewTime(time.Now().UTC().Add(20 * time.Second)),
 			},
-			Status: v1beta1.TaskRunStatus{
+			Status: v1.TaskRunStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 0,
 					Conditions: duckv1.Conditions{{
@@ -122,13 +132,13 @@ func TestPipelineRunGapCollection(t *testing.T) {
 					}},
 					Annotations: nil,
 				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
 					StartTime: &metav1.Time{Time: time.Now().UTC().Add(25 * time.Second)},
 				},
 			},
 		},
 	}
-	mockPipelineRuns := []*v1beta1.PipelineRun{
+	mockPipelineRuns := []*v1.PipelineRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "test-pipelinerun-4",
@@ -136,7 +146,7 @@ func TestPipelineRunGapCollection(t *testing.T) {
 				UID:               types.UID("test-pipelinerun-4"),
 				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
 			},
-			Status: v1beta1.PipelineRunStatus{
+			Status: v1.PipelineRunStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 0,
 					Conditions: duckv1.Conditions{{
@@ -145,8 +155,8 @@ func TestPipelineRunGapCollection(t *testing.T) {
 					}},
 					Annotations: nil,
 				},
-				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-					ChildReferences: []v1beta1.ChildStatusReference{
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					ChildReferences: []v1.ChildStatusReference{
 						{
 							TypeMeta: runtime.TypeMeta{
 								Kind: "TaskRun",
@@ -197,20 +207,20 @@ func TestTaskRunGapEventFilter_Update(t *testing.T) {
 	filter := &taskRunGapEventFilter{}
 	for _, tc := range []struct {
 		name       string
-		oldPR      *v1beta1.PipelineRun
-		newPR      *v1beta1.PipelineRun
+		oldPR      *v1.PipelineRun
+		newPR      *v1.PipelineRun
 		expectedRC bool
 	}{
 		{
 			name:  "not done no status",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{},
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{},
 		},
 		{
 			name:  "not done status unknown",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						Conditions: []apis.Condition{
 							{
@@ -224,9 +234,9 @@ func TestTaskRunGapEventFilter_Update(t *testing.T) {
 		},
 		{
 			name:  "just done succeed",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						Conditions: []apis.Condition{
 							{
@@ -241,9 +251,9 @@ func TestTaskRunGapEventFilter_Update(t *testing.T) {
 		},
 		{
 			name:  "just done failed",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						Conditions: []apis.Condition{
 							{
@@ -258,8 +268,8 @@ func TestTaskRunGapEventFilter_Update(t *testing.T) {
 		},
 		{
 			name: "udpate after done",
-			oldPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						Conditions: []apis.Condition{
 							{
@@ -270,8 +280,8 @@ func TestTaskRunGapEventFilter_Update(t *testing.T) {
 					},
 				},
 			},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						Conditions: []apis.Condition{
 							{

--- a/collector/rawyaml.go
+++ b/collector/rawyaml.go
@@ -1,5 +1,10 @@
 package collector
 
+/*
+For now at least, we are keeping these as v1beta1 to have some element of regression testing, now that we've flipped
+the "default" to v1.
+*/
+
 const prYaml = `
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun

--- a/collector/task_reference_wait_time_test.go
+++ b/collector/task_reference_wait_time_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -20,21 +20,21 @@ func TestTaskRefWaitTimeFilter_Update(t *testing.T) {
 	now := time.Now()
 	for _, tc := range []struct {
 		name                  string
-		oldTR                 *v1beta1.TaskRun
-		newTR                 *v1beta1.TaskRun
+		oldTR                 *v1.TaskRun
+		newTR                 *v1.TaskRun
 		expectedRC            bool
 		expectedNonZeroMetric bool
 	}{
 		{
 			name:  "not started",
-			oldTR: &v1beta1.TaskRun{},
-			newTR: &v1beta1.TaskRun{},
+			oldTR: &v1.TaskRun{},
+			newTR: &v1.TaskRun{},
 		},
 		{
 			name:  "done",
-			oldTR: &v1beta1.TaskRun{},
-			newTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
+			oldTR: &v1.TaskRun{},
+			newTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:   apis.ConditionSucceeded,
@@ -46,25 +46,25 @@ func TestTaskRefWaitTimeFilter_Update(t *testing.T) {
 		},
 		{
 			name: "both running, same transition time",
-			oldTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
+			oldTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
 							Status:             corev1.ConditionUnknown,
-							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							Reason:             v1.TaskRunReasonResolvingTaskRef,
 							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
 						},
 					}},
 				},
 			},
-			newTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
+			newTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
 							Status:             corev1.ConditionUnknown,
-							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							Reason:             v1.TaskRunReasonResolvingTaskRef,
 							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
 						},
 					}},
@@ -73,25 +73,25 @@ func TestTaskRefWaitTimeFilter_Update(t *testing.T) {
 		},
 		{
 			name: "both running, diff transition time",
-			oldTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
+			oldTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
 							Status:             corev1.ConditionUnknown,
-							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							Reason:             v1.TaskRunReasonResolvingTaskRef,
 							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
 						},
 					}},
 				},
 			},
-			newTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
+			newTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
 							Status:             corev1.ConditionUnknown,
-							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							Reason:             v1.TaskRunReasonResolvingTaskRef,
 							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now.Add(1 * time.Second))},
 						},
 					}},
@@ -101,25 +101,25 @@ func TestTaskRefWaitTimeFilter_Update(t *testing.T) {
 		{
 			name:                  "wait over",
 			expectedNonZeroMetric: true,
-			oldTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
+			oldTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
 							Status:             corev1.ConditionUnknown,
-							Reason:             v1beta1.TaskRunReasonResolvingTaskRef,
+							Reason:             v1.TaskRunReasonResolvingTaskRef,
 							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now)},
 						},
 					}},
 				},
 			},
-			newTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
+			newTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
 					Status: duckv1.Status{Conditions: duckv1.Conditions{
 						{
 							Type:               apis.ConditionSucceeded,
 							Status:             corev1.ConditionUnknown,
-							Reason:             v1beta1.TaskRunReasonRunning.String(),
+							Reason:             v1.TaskRunReasonRunning.String(),
 							LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(now.Add(1 * time.Second))},
 						},
 					}},

--- a/collector/taskrun_create_to_start_time_test.go
+++ b/collector/taskrun_create_to_start_time_test.go
@@ -3,7 +3,7 @@ package collector
 import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,34 +18,34 @@ func TestTaskRunStartTimeEventFilter_Update(t *testing.T) {
 	filter := &trStartTimeEventFilter{}
 	for _, tc := range []struct {
 		name       string
-		oldTR      *v1beta1.TaskRun
-		newTR      *v1beta1.TaskRun
+		oldTR      *v1.TaskRun
+		newTR      *v1.TaskRun
 		expectedRC bool
 	}{
 		{
 			name:  "not started",
-			oldTR: &v1beta1.TaskRun{},
-			newTR: &v1beta1.TaskRun{},
+			oldTR: &v1.TaskRun{},
+			newTR: &v1.TaskRun{},
 		},
 		{
 			name:  "just started",
-			oldTR: &v1beta1.TaskRun{},
-			newTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
-					TaskRunStatusFields: v1beta1.TaskRunStatusFields{StartTime: &metav1.Time{}},
+			oldTR: &v1.TaskRun{},
+			newTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{StartTime: &metav1.Time{}},
 				},
 			},
 		},
 		{
 			name: "udpate after started",
-			oldTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
-					TaskRunStatusFields: v1beta1.TaskRunStatusFields{StartTime: &metav1.Time{}},
+			oldTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{StartTime: &metav1.Time{}},
 				},
 			},
-			newTR: &v1beta1.TaskRun{
-				Status: v1beta1.TaskRunStatus{
-					TaskRunStatusFields: v1beta1.TaskRunStatusFields{StartTime: &metav1.Time{}},
+			newTR: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{StartTime: &metav1.Time{}},
 				},
 			},
 		},
@@ -66,7 +66,7 @@ func TestTaskRunStartTimeEventFilter_Update(t *testing.T) {
 }
 
 func TestTaskRunScheduledCollection(t *testing.T) {
-	mockTaskRuns := []*v1beta1.TaskRun{
+	mockTaskRuns := []*v1.TaskRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "test-taskrun-1",
@@ -74,7 +74,7 @@ func TestTaskRunScheduledCollection(t *testing.T) {
 				UID:               types.UID("test-taskrun-1"),
 				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
 			},
-			Status: v1beta1.TaskRunStatus{
+			Status: v1.TaskRunStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 0,
 					Conditions: duckv1.Conditions{{
@@ -83,7 +83,7 @@ func TestTaskRunScheduledCollection(t *testing.T) {
 					}},
 					Annotations: nil,
 				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
 					StartTime:      &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
 					CompletionTime: &metav1.Time{Time: time.Now().UTC().Add(10 * time.Second)},
 				},
@@ -96,7 +96,7 @@ func TestTaskRunScheduledCollection(t *testing.T) {
 				UID:               types.UID("test-taskrun-2"),
 				CreationTimestamp: metav1.NewTime(time.Now().UTC()),
 			},
-			Status: v1beta1.TaskRunStatus{
+			Status: v1.TaskRunStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 0,
 					Conditions: duckv1.Conditions{{
@@ -105,7 +105,7 @@ func TestTaskRunScheduledCollection(t *testing.T) {
 					}},
 					Annotations: nil,
 				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
 					StartTime: &metav1.Time{Time: time.Now().UTC().Add(5 * time.Second)},
 				},
 			},
@@ -125,17 +125,17 @@ func TestCalculateTaskRunScheduledDuration(t *testing.T) {
 	now := time.Now()
 	for _, tc := range []struct {
 		expectedAmt float64
-		tr          *v1beta1.TaskRun
+		tr          *v1.TaskRun
 	}{
 		{
 			expectedAmt: 5,
-			tr: &v1beta1.TaskRun{
+			tr: &v1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-taskrun-1",
 					Namespace:         "test-namespace",
 					CreationTimestamp: metav1.NewTime(now),
 				},
-				Status: v1beta1.TaskRunStatus{
+				Status: v1.TaskRunStatus{
 					Status: duckv1.Status{
 						ObservedGeneration: 0,
 						Conditions: duckv1.Conditions{{
@@ -144,7 +144,7 @@ func TestCalculateTaskRunScheduledDuration(t *testing.T) {
 						}},
 						Annotations: nil,
 					},
-					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
 						StartTime:      &metav1.Time{Time: now.Add(5 * time.Second)},
 						CompletionTime: &metav1.Time{Time: now.Add(10 * time.Second)},
 					},
@@ -153,13 +153,13 @@ func TestCalculateTaskRunScheduledDuration(t *testing.T) {
 		},
 		{
 			expectedAmt: 5,
-			tr: &v1beta1.TaskRun{
+			tr: &v1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-taskrun-1",
 					Namespace:         "test-namespace",
 					CreationTimestamp: metav1.NewTime(now),
 				},
-				Status: v1beta1.TaskRunStatus{
+				Status: v1.TaskRunStatus{
 					Status: duckv1.Status{
 						ObservedGeneration: 0,
 						Conditions: duckv1.Conditions{{
@@ -168,7 +168,7 @@ func TestCalculateTaskRunScheduledDuration(t *testing.T) {
 						}},
 						Annotations: nil,
 					},
-					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
 						StartTime:      &metav1.Time{Time: now.Add(5 * time.Second)},
 						CompletionTime: &metav1.Time{Time: now.Add(10 * time.Second)},
 					},

--- a/collector/throttled_by_pvc_count_test.go
+++ b/collector/throttled_by_pvc_count_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,20 +23,20 @@ func TestPvcThrottledFilter_Update(t *testing.T) {
 	filter := &pvcThrottledFilter{}
 	for _, tc := range []struct {
 		name       string
-		oldPR      *v1beta1.PipelineRun
-		newPR      *v1beta1.PipelineRun
+		oldPR      *v1.PipelineRun
+		newPR      *v1.PipelineRun
 		expectedRC bool
 	}{
 		{
 			name:  "not failed",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{},
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{},
 		},
 		{
 			name:  "failed with right reason and message",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{
 							apis.Condition{
@@ -53,9 +53,9 @@ func TestPvcThrottledFilter_Update(t *testing.T) {
 		},
 		{
 			name:  "failed with right reason but wrong message",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{
 							apis.Condition{
@@ -71,9 +71,9 @@ func TestPvcThrottledFilter_Update(t *testing.T) {
 		},
 		{
 			name:  "failed with right message but wrong reason",
-			oldPR: &v1beta1.PipelineRun{},
-			newPR: &v1beta1.PipelineRun{
-				Status: v1beta1.PipelineRunStatus{
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{
+				Status: v1.PipelineRunStatus{
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{
 							apis.Condition{
@@ -102,13 +102,13 @@ func TestPvcThrottledFilter_Update(t *testing.T) {
 func TestResetPVCStats(t *testing.T) {
 	objs := []client.Object{}
 	scheme := runtime.NewScheme()
-	_ = v1beta1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 
-	mockPipelineRuns := []*v1beta1.PipelineRun{
+	mockPipelineRuns := []*v1.PipelineRun{
 		{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-1"},
-			Status: v1beta1.PipelineRunStatus{
+			Status: v1.PipelineRunStatus{
 				Status: duckv1.Status{
 					Conditions: duckv1.Conditions{
 						apis.Condition{
@@ -123,7 +123,7 @@ func TestResetPVCStats(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-2"},
-			Status: v1beta1.PipelineRunStatus{
+			Status: v1.PipelineRunStatus{
 				Status: duckv1.Status{
 					Conditions: duckv1.Conditions{
 						apis.Condition{

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -18,7 +18,7 @@ package collector
 
 import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"os"
 	"strconv"
 	"strings"
@@ -37,7 +37,7 @@ const (
 	FAILED                              = "failed"
 )
 
-func pipelineRunPipelineRef(pr *v1beta1.PipelineRun) string {
+func pipelineRunPipelineRef(pr *v1.PipelineRun) string {
 	val := ""
 	ref := pr.Spec.PipelineRef
 	if ref != nil {

--- a/collector/utils_test.go
+++ b/collector/utils_test.go
@@ -5,6 +5,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -42,12 +43,14 @@ func validateGaugeVec(t *testing.T, g *prometheus.GaugeVec, labels prometheus.La
 	assert.Equal(t, count, *metric.Gauge.Value)
 }
 
+// For now at least, we are keeping these as v1beta1 to have some element of regression testing, now that we've flipped
+// the "default" to v1.
 func pipelineRunFromActualRHTAPYaml() ([]v1beta1.PipelineRun, error) {
 	prs := []v1beta1.PipelineRun{}
 	yamlStrings := []string{tooBigNumPRYaml,
 		prYaml}
 
-	v1beta1.AddToScheme(scheme.Scheme)
+	v1.AddToScheme(scheme.Scheme)
 	decoder := scheme.Codecs.UniversalDecoder()
 	for _, y := range yamlStrings {
 		buf := []byte(y)
@@ -61,6 +64,8 @@ func pipelineRunFromActualRHTAPYaml() ([]v1beta1.PipelineRun, error) {
 	return prs, nil
 }
 
+// For now at least, we are keeping these as v1beta1 to have some element of regression testing, now that we've flipped
+// the "default" to v1.
 func taskRunsFromActualRHTAPYaml() ([]v1beta1.TaskRun, error) {
 	trs := []v1beta1.TaskRun{}
 	yamlStrings := []string{tooBigNumTRInitYaml,
@@ -79,7 +84,7 @@ func taskRunsFromActualRHTAPYaml() ([]v1beta1.TaskRun, error) {
 		trClairYaml,
 		trSummaryYaml,
 		trShowSbomYaml}
-	v1beta1.AddToScheme(scheme.Scheme)
+	v1.AddToScheme(scheme.Scheme)
 	decoder := scheme.Codecs.UniversalDecoder()
 	for _, y := range yamlStrings {
 		buf := []byte(y)
@@ -97,12 +102,12 @@ func TestPipelineRunPipelineRef(t *testing.T) {
 	for _, test := range []struct {
 		name           string
 		expectedReturn string
-		pr             *v1beta1.PipelineRun
+		pr             *v1.PipelineRun
 	}{
 		{
 			name:           "use pipeline run name",
 			expectedReturn: "test-pipelinerun",
-			pr: &v1beta1.PipelineRun{
+			pr: &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pipelinerun",
 				},
@@ -111,7 +116,7 @@ func TestPipelineRunPipelineRef(t *testing.T) {
 		{
 			name:           "use pipelinerun run generate name",
 			expectedReturn: "test-pipelinerun-",
-			pr: &v1beta1.PipelineRun{
+			pr: &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:         "test-pipelinerun-foo",
 					GenerateName: "test-pipelinerun-",
@@ -121,18 +126,18 @@ func TestPipelineRunPipelineRef(t *testing.T) {
 		{
 			name:           "use pipeline run ref param name",
 			expectedReturn: "test-pipeline",
-			pr: &v1beta1.PipelineRun{
+			pr: &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:         "test-pipelinerun-foo",
 					GenerateName: "test-pipelinerun-",
 				},
-				Spec: v1beta1.PipelineRunSpec{
-					PipelineRef: &v1beta1.PipelineRef{
-						ResolverRef: v1beta1.ResolverRef{
-							Params: []v1beta1.Param{
+				Spec: v1.PipelineRunSpec{
+					PipelineRef: &v1.PipelineRef{
+						ResolverRef: v1.ResolverRef{
+							Params: []v1.Param{
 								{
 									Name: "name",
-									Value: v1beta1.ParamValue{
+									Value: v1.ParamValue{
 										StringVal: "test-pipeline"},
 								},
 							},
@@ -144,12 +149,12 @@ func TestPipelineRunPipelineRef(t *testing.T) {
 		{
 			name:           "use pipeline run ref name",
 			expectedReturn: "test-pipeline",
-			pr: &v1beta1.PipelineRun{
+			pr: &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:         "test-pipelinerun-foo",
 					GenerateName: "test-pipelinerun-",
 				},
-				Spec: v1beta1.PipelineRunSpec{PipelineRef: &v1beta1.PipelineRef{Name: "test-pipeline"}},
+				Spec: v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: "test-pipeline"}},
 			},
 		},
 	} {


### PR DESCRIPTION
fyi left some usage of v1beta1 in the unit tests (rawyaml.go), where I mimic the v1beta1 to v1 conversion done in the upstream tekton conversion webhook 

there is a tl;dr level analysis in https://issues.redhat.com/browse/RHTAP-1048?focusedId=23158263&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23158263 around how we can just watch for v1 type objects and still get v1beta1 type objects 