### PR TITLE
PLNSRVCE-1497: additional protection to not start controller-runtime watches too soon

### DIFF
--- a/collector/throttled_by_pvc_count.go
+++ b/collector/throttled_by_pvc_count.go
@@ -93,6 +93,7 @@ func (r *ReconcilePVCThrottled) Start(ctx context.Context) error {
 		case <-eventTicker.C:
 			r.resetPVCStats(ctx)
 		case <-ctx.Done():
+			controllerLog.Info("ReconcilePVCThrottled Runnable context is marked as done, exiting")
 			eventTicker.Stop()
 			return nil
 		}


### PR DESCRIPTION
For whatever reason, in the 4 RHTAP clusters, the multi-tenant prod cluster sees some periodic instances of the metrics-exporter having to restart. After a few instances, we finally got some useful information in the previous logs.  As it turns out, even after the CRDs are available, if we hit things too soon as Tekton is still coming up, the controller-runtime's attempts to establish watches either get 500s or time out, causing controller-runtime to exit, and our metrics-exporter pod restarting.  This change adds a List operation after the get CRD operation in our retry loop to help discern that apiserver plus Tekton is really ready to receiving watch/list requests.

@openshift-pipelines/pipelines-service FYI 

Error logs that can occur:
```
{"level":"info","ts":"2023-10-12T13:10:02Z","msg":"Starting workers","controller":"taskrun","controllerGroup":"tekton.dev","controllerKind":"TaskRun","worker count":1}
E1012 13:13:05.403666 1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: Failed to watch *v1.TaskRun: the server is currently unable to handle the request (get taskruns.tekton.dev)
E1012 13:13:05.422135 1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: Failed to watch *v1.PipelineRun: the server is currently unable to handle the request (get pipelineruns.tekton.dev)
I1012 13:13:25.202769 1 trace.go:219] Trace[573645445]: "Reflector ListAndWatch" name:pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169 (12-Oct-2023 13:13:06.401) (total time: 18801ms):
Trace[573645445]: ---"Objects listed" error:<nil> 18800ms (13:13:25.201)
Trace[573645445]: [18.801676435s] [18.801676435s] END
W1012 13:14:06.645016 1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: failed to list *v1.TaskRun: the server was unable to return a response in the time allotted, but may still be processing the request (get taskruns.tekton.dev)
I1012 13:14:06.645069 1 trace.go:219] Trace[1055873950]: "Reflector ListAndWatch" name:pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169 (12-Oct-2023 13:13:06.643) (total time: 60001ms):
Trace[1055873950]: ---"Objects listed" error:the server was unable to return a response in the time allotted, but may still be processing the request (get taskruns.tekton.dev) 60001ms (13:14:06.645)
Trace[1055873950]: [1m0.001462906s] [1m0.001462906s] END
E1012 13:14:06.645093 1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: Failed to watch *v1.TaskRun: failed to list *v1.TaskRun: the server was unable to return a response in the time allotted, but may still be processing the request (get taskruns.tekton.dev)
```