### PR TITLE
PLNSRVCE-1418,PLNSRVCE-1419: create an aggregated metric with filtering for our overhead alerts

### DIFF
--- a/collector/controller.go
+++ b/collector/controller.go
@@ -136,5 +136,10 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 		return nil, err
 	}
 
+	err = SetupOverheadController(mgr)
+	if err != nil {
+		return nil, err
+	}
+
 	return mgr, nil
 }

--- a/collector/overhead_alert_metrics.go
+++ b/collector/overhead_alert_metrics.go
@@ -1,0 +1,119 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func SetupOverheadController(mgr ctrl.Manager) error {
+	reconciler := &ReconcileOverhead{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		eventRecorder: mgr.GetEventRecorderFor("MetricExporterExecutionOverhead"),
+		collector:     NewOverheadCollector(),
+	}
+	return ctrl.NewControllerManagedBy(mgr).For(&v1.PipelineRun{}).WithEventFilter(&taskRunGapEventFilter{}).Complete(reconciler)
+}
+
+type OverheadCollector struct {
+	execution  *prometheus.HistogramVec
+	scheduling *prometheus.HistogramVec
+}
+
+type ReconcileOverhead struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+	collector     *OverheadCollector
+}
+
+func NewOverheadCollector() *OverheadCollector {
+	labelNames := []string{NS_LABEL, STATUS_LABEL}
+	executionMetric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "pipeline_service_execution_overhead_percentage",
+		Help:    "Proportion of time elapsed between the completion of a TaskRun and the start of the next TaskRun within a PipelineRun to the total duration of successful PipelineRuns",
+		Buckets: prometheus.DefBuckets,
+	}, labelNames)
+	schedulingMetric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "pipeline_service_schedule_overhead_percentage",
+		Help:    "Proportion of time elapsed waiting for the pipeline controller to receive create events compared to the total duration of successful PipelineRuns",
+		Buckets: prometheus.DefBuckets,
+	}, labelNames)
+	collector := &OverheadCollector{execution: executionMetric, scheduling: schedulingMetric}
+	metrics.Registry.MustRegister(executionMetric, schedulingMetric)
+	return collector
+}
+
+func (r *ReconcileOverhead) accumulateGaps(pr *v1.PipelineRun, oc client.Client, ctx context.Context) (float64, bool) {
+	if prNotDoneOrHasNoKids(pr) {
+		return float64(0), false
+	}
+	gapTotal := float64(0)
+
+	sortedTaskRunsByCreateTimes, reverseOrderSortedTaskRunsByCompletionTimes := sortTaskRunsForGapCalculations(pr, oc, ctx)
+
+	gapEntries := calculateGaps(ctx, pr, oc, sortedTaskRunsByCreateTimes, reverseOrderSortedTaskRunsByCompletionTimes)
+	for _, gapEntry := range gapEntries {
+		gapTotal = gapTotal + gapEntry.gap
+	}
+
+	return gapTotal, true
+}
+
+func (r *ReconcileOverhead) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+	log := log.FromContext(ctx)
+
+	pr := &v1.PipelineRun{}
+	err := r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: request.Name}, pr)
+	if err != nil && !errors.IsNotFound(err) {
+		return reconcile.Result{}, err
+	}
+	if err != nil {
+		log.V(4).Info(fmt.Sprintf("ignoring deleted pipelinerun %q", request.NamespacedName))
+		return reconcile.Result{}, nil
+	}
+	succeedCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
+	if succeedCondition != nil && !succeedCondition.IsUnknown() {
+		gapTotal, foundGaps := r.accumulateGaps(pr, r.client, ctx)
+		status := SUCCEEDED
+		if succeedCondition.IsFalse() {
+			status = FAILED
+		}
+		labels := map[string]string{NS_LABEL: pr.Namespace, STATUS_LABEL: status}
+		totalDuration := float64(pr.Status.CompletionTime.Time.Sub(pr.Status.StartTime.Time).Milliseconds())
+		if foundGaps {
+			if !filter(gapTotal, totalDuration) {
+				overhead := gapTotal / totalDuration
+				r.collector.execution.With(labels).Observe(overhead)
+			} else {
+				log.V(4).Info(fmt.Sprintf("filtering execution metric for %s with gap %v and total %v",
+					request.NamespacedName.String(), gapTotal, totalDuration))
+			}
+		}
+		scheduleDuration := calculateScheduledDuration(pr.CreationTimestamp.Time, pr.Status.StartTime.Time)
+		if !filter(scheduleDuration, totalDuration) {
+			overhead := scheduleDuration / totalDuration
+			r.collector.scheduling.With(labels).Observe(overhead)
+		} else {
+			log.V(4).Info(fmt.Sprintf("filtering scheduling metric for %s with gap %v and total %v",
+				request.NamespacedName.String(), scheduleDuration, totalDuration))
+		}
+	}
+	return reconcile.Result{}, nil
+
+}

--- a/collector/overhead_alert_metrics_test.go
+++ b/collector/overhead_alert_metrics_test.go
@@ -1,0 +1,71 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+)
+
+func TestReconcileOverhead_Reconcile(t *testing.T) {
+	// rather than using golang mocks, grabbed actual RHTAP pipelinerun/taskruns from staging
+	// to drive the gap metric, given its trickiness
+	objs := []client.Object{}
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	_ = v1beta1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	overheadReconciler := &ReconcileOverhead{
+		client:    c,
+		collector: NewOverheadCollector(),
+	}
+	var err error
+	// first we test with the samples pulled from actual RHTAP yaml to best capture the parallel task executions
+	prs := []v1beta1.PipelineRun{}
+	trs := []v1beta1.TaskRun{}
+	prs, err = pipelineRunFromActualRHTAPYaml()
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("%s", err.Error()))
+	}
+	trs, err = taskRunsFromActualRHTAPYaml()
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("%s", err.Error()))
+	}
+
+	ctx := context.TODO()
+	for _, trv1beta1 := range trs {
+		// mimic what the tekton conversion webhook will do
+		tr := &v1.TaskRun{}
+		err = trv1beta1.ConvertTo(ctx, tr)
+		assert.NoError(t, err)
+		err = c.Create(ctx, tr)
+		assert.NoError(t, err)
+	}
+	for _, prv1beta1 := range prs {
+		// mimic what the tekton conversion webhook will do
+		pr := &v1.PipelineRun{}
+		err = prv1beta1.ConvertTo(ctx, pr)
+		assert.NoError(t, err)
+		err = c.Create(ctx, pr)
+		assert.NoError(t, err)
+		request := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: pr.Namespace,
+				Name:      pr.Name,
+			},
+		}
+		_, err = overheadReconciler.Reconcile(ctx, request)
+		label := prometheus.Labels{NS_LABEL: pr.Namespace, STATUS_LABEL: SUCCEEDED}
+		validateHistogramVec(t, overheadReconciler.collector.scheduling, label, true)
+		validateHistogramVec(t, overheadReconciler.collector.execution, label, true)
+	}
+
+}

--- a/collector/pipelinerun_create_to_start_time.go
+++ b/collector/pipelinerun_create_to_start_time.go
@@ -57,7 +57,7 @@ func bumpPipelineRunScheduledDuration(scheduleDuration float64, pr *v1.PipelineR
 }
 
 func calculateScheduledDurationPipelineRun(pipelineRun *v1.PipelineRun) float64 {
-	return calcuateScheduledDuration(pipelineRun.CreationTimestamp.Time, pipelineRun.Status.StartTime.Time)
+	return calculateScheduledDuration(pipelineRun.CreationTimestamp.Time, pipelineRun.Status.StartTime.Time) / 1000
 }
 
 type ReconcilePipelineRunScheduled struct {

--- a/collector/pipelinerun_taskrun_complete_create_gaps.go
+++ b/collector/pipelinerun_taskrun_complete_create_gaps.go
@@ -9,15 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sort"
-	"time"
 )
 
 func SetupPipelineRunTaskRunGapController(mgr ctrl.Manager) error {
@@ -119,129 +116,25 @@ func (r *ReconcilePipelineRunTaskRunGap) Reconcile(ctx context.Context, request 
 }
 
 func (c *PipelineRunTaskRunGapCollector) bumpGapDuration(pr *v1.PipelineRun, oc client.Client, ctx context.Context) {
-	if len(pr.Status.ChildReferences) < 1 {
-		return
-	}
-	// in case there are gaps between a pipelinerun being marked done but the complete timestamp is not set, with the
-	// understanding that the complete timestamp is not processed before any completed taskrun complete timestamps have been processed
-	if pr.Status.CompletionTime == nil {
+	if prNotDoneOrHasNoKids(pr) {
 		return
 	}
 
-	sortedTaskRunsByCreateTimes := []*v1.TaskRun{}
-	reverseOrderSortedTaskRunsByCompletionTimes := []*v1.TaskRun{}
-	// prior testing in staging proved that with enough concurrency, this array is minimally not sorted based on when
-	// the task runs were created, so we explicitly sort for that; also, this sorting will allow us to effectively
-	// address parallel taskruns vs. taskrun dependencies and ordering (where tekton does not create a taskrun until its dependencies
-	// have completed).
-	for _, kidRef := range pr.Status.ChildReferences {
-		if kidRef.Kind != "TaskRun" {
-			continue
-		}
-		kid := &v1.TaskRun{}
-		err := oc.Get(ctx, types.NamespacedName{Namespace: pr.Namespace, Name: kidRef.Name}, kid)
-		if err != nil {
-			ctrl.Log.Info(fmt.Sprintf("could not calculate gap for taskrun %s:%s: %s", pr.Namespace, kidRef.Name, err.Error()))
-			continue
-		}
+	sortedTaskRunsByCreateTimes, reverseOrderSortedTaskRunsByCompletionTimes := sortTaskRunsForGapCalculations(pr, oc, ctx)
 
-		sortedTaskRunsByCreateTimes = append(sortedTaskRunsByCreateTimes, kid)
-		// don't add taskruns that did not complete i.e. presumably timed out of failed; any taskruns that dependended
-		// on should not have even been created
-		if kid.Status.CompletionTime != nil {
-			reverseOrderSortedTaskRunsByCompletionTimes = append(reverseOrderSortedTaskRunsByCompletionTimes, kid)
-
-		}
-	}
-	sort.SliceStable(sortedTaskRunsByCreateTimes, func(i, j int) bool {
-		return sortedTaskRunsByCreateTimes[i].CreationTimestamp.Time.Before(sortedTaskRunsByCreateTimes[j].CreationTimestamp.Time)
-	})
-	sort.SliceStable(reverseOrderSortedTaskRunsByCompletionTimes, func(i, j int) bool {
-		return reverseOrderSortedTaskRunsByCompletionTimes[i].Status.CompletionTime.Time.After(reverseOrderSortedTaskRunsByCompletionTimes[j].Status.CompletionTime.Time)
-	})
 	prRef := pipelineRunPipelineRef(pr)
-	for index, tr := range sortedTaskRunsByCreateTimes {
-		succeedCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
-		if succeedCondition == nil {
-			ctrl.Log.Info(fmt.Sprintf("WARNING: pipielinerun %s:%s marked done but has nil succeed condition", pr.Namespace, pr.Name))
-			continue
+	gapEntries := calculateGaps(ctx, pr, oc, sortedTaskRunsByCreateTimes, reverseOrderSortedTaskRunsByCompletionTimes)
+	for _, gapEntry := range gapEntries {
+		labels := map[string]string{
+			NS_LABEL:     pr.Namespace,
+			STATUS_LABEL: gapEntry.status,
 		}
-		if succeedCondition.IsUnknown() {
-			ctrl.Log.Info(fmt.Sprintf("WARNING: pipielinerun %s:%s marked done but has unknown succeed condition", pr.Namespace, pr.Name))
-			continue
-		}
-		status := SUCCEEDED
-		if succeedCondition.IsFalse() {
-			status = FAILED
-		}
-		labels := map[string]string{NS_LABEL: pr.Namespace, STATUS_LABEL: status}
 		if c.additionalLabels {
 			labels[PIPELINE_NAME_LABEL] = prRef
+			labels[COMPLETED_LABEL] = gapEntry.completed
+			labels[UPCOMING_LABEL] = gapEntry.upcoming
 		}
-
-		if index == 0 {
-			ctrl.Log.V(4).Info(fmt.Sprintf("first task %s for pipeline %s", taskRef(tr.Labels), prRef))
-			// our first task is simple, just work off of the pipelinerun
-			gap := tr.CreationTimestamp.Time.Sub(pr.CreationTimestamp.Time).Milliseconds()
-			if c.additionalLabels {
-				labels[COMPLETED_LABEL] = prRef
-				labels[UPCOMING_LABEL] = taskRef(tr.Labels)
-			}
-			c.trGaps.With(labels).Observe(float64(gap))
-			continue
-		}
-
-		firstKid := sortedTaskRunsByCreateTimes[0]
-
-		// so using the first taskrun completion time addresses sequential / chaining dependencies;
-		// for parallel, if the first taskrun's completion time is not after this taskrun's create time,
-		// that means parallel taskruns, and we work off of the pipelinerun; NOTE: this focuses on "top level" parallel task runs
-		// with absolutely no dependencies.  Once any sort of dependency is established, there are no more top level parallel taskruns.
-		if firstKid.Status.CompletionTime != nil && firstKid.Status.CompletionTime.Time.After(tr.CreationTimestamp.Time) {
-			ctrl.Log.V(4).Info(fmt.Sprintf("task %s considered parallel for pipeline %s", taskRef(tr.Labels), prRef))
-			gap := tr.CreationTimestamp.Time.Sub(pr.CreationTimestamp.Time).Milliseconds()
-			if c.additionalLabels {
-				labels[COMPLETED_LABEL] = prRef
-				labels[UPCOMING_LABEL] = taskRef(tr.Labels)
-			}
-			c.trGaps.With(labels).Observe(float64(gap))
-			continue
-		}
-
-		// Conversely, task run chains can run in parallel, and a taskrun can depend on multiple chains or threads of taskruns. We want to find the chain
-		// that finished last, but before we are created.  We traverse through our reverse sorted on completion time list to determine that.  But yes, we don't reproduce the DAG
-		// graph (there is no clean dependency import path in tekton for that) to confirm the edges.  This approximation is sufficient.
-
-		// get whatever completed first
-		timeToCalculateWith := time.Time{}
-		trToCalculateWith := &v1.TaskRun{}
-		if len(reverseOrderSortedTaskRunsByCompletionTimes) > 0 {
-			trToCalculateWith = reverseOrderSortedTaskRunsByCompletionTimes[len(reverseOrderSortedTaskRunsByCompletionTimes)-1]
-			timeToCalculateWith = trToCalculateWith.Status.CompletionTime.Time
-		} else {
-			// if no taskruns completed, that means any taskruns created were created as part of the initial pipelinerun creation,
-			// so use the pipelinerun creation time
-			timeToCalculateWith = pr.CreationTimestamp.Time
-		}
-		for _, tr2 := range reverseOrderSortedTaskRunsByCompletionTimes {
-			if tr2.Name == tr.Name {
-				continue
-			}
-			ctrl.Log.V(4).Info(fmt.Sprintf("comparing candidate %s to current task %s", taskRef(tr2.Labels), taskRef(tr.Labels)))
-			if !tr2.Status.CompletionTime.Time.After(tr.CreationTimestamp.Time) {
-				ctrl.Log.V(4).Info(fmt.Sprintf("%s did not complete after so use it to compute gap for current task %s", taskRef(tr2.Labels), taskRef(tr.Labels)))
-				trToCalculateWith = tr2
-				timeToCalculateWith = tr2.Status.CompletionTime.Time
-				break
-			}
-			ctrl.Log.V(4).Info(fmt.Sprintf("skipping %s as a gap candidate for current task %s is OK", taskRef(tr2.Labels), taskRef(tr.Labels)))
-		}
-		gap := tr.CreationTimestamp.Time.Sub(timeToCalculateWith).Milliseconds()
-		if c.additionalLabels {
-			labels[COMPLETED_LABEL] = taskRef(trToCalculateWith.Labels)
-			labels[UPCOMING_LABEL] = taskRef(tr.Labels)
-		}
-		c.trGaps.With(labels).Observe(float64(gap))
+		c.trGaps.With(labels).Observe(gapEntry.gap)
 	}
 
 	return

--- a/collector/taskrun_create_to_start_time.go
+++ b/collector/taskrun_create_to_start_time.go
@@ -114,5 +114,5 @@ func bumpTaskRunScheduledDuration(scheduleDuration float64, tr *v1.TaskRun, metr
 }
 
 func calculateScheduledDurationTaskRun(taskrun *v1.TaskRun) float64 {
-	return calcuateScheduledDuration(taskrun.CreationTimestamp.Time, taskrun.Status.StartTime.Time)
+	return calculateScheduledDuration(taskrun.CreationTimestamp.Time, taskrun.Status.StartTime.Time)
 }

--- a/collector/taskrun_create_to_start_time_test.go
+++ b/collector/taskrun_create_to_start_time_test.go
@@ -149,7 +149,7 @@ func TestCalculateTaskRunScheduledDuration(t *testing.T) {
 		tr          *v1.TaskRun
 	}{
 		{
-			expectedAmt: 5,
+			expectedAmt: 5000,
 			tr: &v1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-taskrun-1",
@@ -173,7 +173,7 @@ func TestCalculateTaskRunScheduledDuration(t *testing.T) {
 			},
 		},
 		{
-			expectedAmt: 5,
+			expectedAmt: 5000,
 			tr: &v1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-taskrun-1",

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -17,9 +17,16 @@
 package collector
 
 import (
+	"context"
+	"fmt"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
 	"os"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -93,9 +100,160 @@ func optionalMetricEnabled(envVarName string) bool {
 	return false
 }
 
-func calcuateScheduledDuration(created, started time.Time) float64 {
+func calculateScheduledDuration(created, started time.Time) float64 {
 	if created.IsZero() || started.IsZero() {
 		return 0
 	}
-	return started.Sub(created).Seconds()
+	return float64(started.Sub(created).Milliseconds())
+}
+
+func prNotDoneOrHasNoKids(pr *v1.PipelineRun) bool {
+	if len(pr.Status.ChildReferences) < 1 {
+		return true
+	}
+	// in case there are gaps between a pipelinerun being marked done but the complete timestamp is not set, with the
+	// understanding that the complete timestamp is not processed before any completed taskrun complete timestamps have been processed
+	if pr.Status.CompletionTime == nil {
+		return true
+	}
+	return false
+}
+
+func sortTaskRunsForGapCalculations(pr *v1.PipelineRun, oc client.Client, ctx context.Context) ([]*v1.TaskRun, []*v1.TaskRun) {
+	sortedTaskRunsByCreateTimes := []*v1.TaskRun{}
+	reverseOrderSortedTaskRunsByCompletionTimes := []*v1.TaskRun{}
+	// prior testing in staging proved that with enough concurrency, this array is minimally not sorted based on when
+	// the task runs were created, so we explicitly sort for that; also, this sorting will allow us to effectively
+	// address parallel taskruns vs. taskrun dependencies and ordering (where tekton does not create a taskrun until its dependencies
+	// have completed).
+	for _, kidRef := range pr.Status.ChildReferences {
+		if kidRef.Kind != "TaskRun" {
+			continue
+		}
+		kid := &v1.TaskRun{}
+		err := oc.Get(ctx, types.NamespacedName{Namespace: pr.Namespace, Name: kidRef.Name}, kid)
+		if err != nil {
+			ctrl.Log.Info(fmt.Sprintf("could not calculate gap for taskrun %s:%s: %s", pr.Namespace, kidRef.Name, err.Error()))
+			continue
+		}
+
+		sortedTaskRunsByCreateTimes = append(sortedTaskRunsByCreateTimes, kid)
+		// don't add taskruns that did not complete i.e. presumably timed out of failed; any taskruns that dependended
+		// on should not have even been created
+		if kid.Status.CompletionTime != nil {
+			reverseOrderSortedTaskRunsByCompletionTimes = append(reverseOrderSortedTaskRunsByCompletionTimes, kid)
+
+		}
+	}
+	sort.SliceStable(sortedTaskRunsByCreateTimes, func(i, j int) bool {
+		return sortedTaskRunsByCreateTimes[i].CreationTimestamp.Time.Before(sortedTaskRunsByCreateTimes[j].CreationTimestamp.Time)
+	})
+	sort.SliceStable(reverseOrderSortedTaskRunsByCompletionTimes, func(i, j int) bool {
+		return reverseOrderSortedTaskRunsByCompletionTimes[i].Status.CompletionTime.Time.After(reverseOrderSortedTaskRunsByCompletionTimes[j].Status.CompletionTime.Time)
+	})
+	return sortedTaskRunsByCreateTimes, reverseOrderSortedTaskRunsByCompletionTimes
+}
+
+type GapEntry struct {
+	status    string
+	pipeline  string
+	completed string
+	upcoming  string
+	gap       float64
+}
+
+func calculateGaps(ctx context.Context, pr *v1.PipelineRun, oc client.Client, sortedTaskRunsByCreateTimes []*v1.TaskRun, reverseOrderSortedTaskRunsByCompletionTimes []*v1.TaskRun) []GapEntry {
+	gapEntries := []GapEntry{}
+	prRef := pipelineRunPipelineRef(pr)
+	for index, tr := range sortedTaskRunsByCreateTimes {
+		succeedCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
+		if succeedCondition == nil {
+			ctrl.Log.Info(fmt.Sprintf("WARNING: pipielinerun %s:%s marked done but has nil succeed condition", pr.Namespace, pr.Name))
+			continue
+		}
+		if succeedCondition.IsUnknown() {
+			ctrl.Log.Info(fmt.Sprintf("WARNING: pipielinerun %s:%s marked done but has unknown succeed condition", pr.Namespace, pr.Name))
+			continue
+		}
+		gapEntry := GapEntry{}
+		status := SUCCEEDED
+		if succeedCondition.IsFalse() {
+			status = FAILED
+		}
+		gapEntry.status = status
+		gapEntry.pipeline = prRef
+
+		if index == 0 {
+			ctrl.Log.V(4).Info(fmt.Sprintf("first task %s for pipeline %s", taskRef(tr.Labels), prRef))
+			// our first task is simple, just work off of the pipelinerun
+			gapEntry.gap = float64(tr.CreationTimestamp.Time.Sub(pr.CreationTimestamp.Time).Milliseconds())
+			gapEntry.completed = prRef
+			gapEntry.upcoming = taskRef(tr.Labels)
+			gapEntries = append(gapEntries, gapEntry)
+			continue
+		}
+
+		firstKid := sortedTaskRunsByCreateTimes[0]
+
+		// so using the first taskrun completion time addresses sequential / chaining dependencies;
+		// for parallel, if the first taskrun's completion time is not after this taskrun's create time,
+		// that means parallel taskruns, and we work off of the pipelinerun; NOTE: this focuses on "top level" parallel task runs
+		// with absolutely no dependencies.  Once any sort of dependency is established, there are no more top level parallel taskruns.
+		if firstKid.Status.CompletionTime != nil && firstKid.Status.CompletionTime.Time.After(tr.CreationTimestamp.Time) {
+			ctrl.Log.V(4).Info(fmt.Sprintf("task %s considered parallel for pipeline %s", taskRef(tr.Labels), prRef))
+			gapEntry.gap = float64(tr.CreationTimestamp.Time.Sub(pr.CreationTimestamp.Time).Milliseconds())
+			gapEntry.completed = prRef
+			gapEntry.upcoming = taskRef(tr.Labels)
+			gapEntries = append(gapEntries, gapEntry)
+			continue
+		}
+
+		// Conversely, task run chains can run in parallel, and a taskrun can depend on multiple chains or threads of taskruns. We want to find the chain
+		// that finished last, but before we are created.  We traverse through our reverse sorted on completion time list to determine that.  But yes, we don't reproduce the DAG
+		// graph (there is no clean dependency import path in tekton for that) to confirm the edges.  This approximation is sufficient.
+
+		// get whatever completed first
+		timeToCalculateWith := time.Time{}
+		trToCalculateWith := &v1.TaskRun{}
+		if len(reverseOrderSortedTaskRunsByCompletionTimes) > 0 {
+			trToCalculateWith = reverseOrderSortedTaskRunsByCompletionTimes[len(reverseOrderSortedTaskRunsByCompletionTimes)-1]
+			timeToCalculateWith = trToCalculateWith.Status.CompletionTime.Time
+		} else {
+			// if no taskruns completed, that means any taskruns created were created as part of the initial pipelinerun creation,
+			// so use the pipelinerun creation time
+			timeToCalculateWith = pr.CreationTimestamp.Time
+		}
+		for _, tr2 := range reverseOrderSortedTaskRunsByCompletionTimes {
+			if tr2.Name == tr.Name {
+				continue
+			}
+			ctrl.Log.V(4).Info(fmt.Sprintf("comparing candidate %s to current task %s", taskRef(tr2.Labels), taskRef(tr.Labels)))
+			if !tr2.Status.CompletionTime.Time.After(tr.CreationTimestamp.Time) {
+				ctrl.Log.V(4).Info(fmt.Sprintf("%s did not complete after so use it to compute gap for current task %s", taskRef(tr2.Labels), taskRef(tr.Labels)))
+				trToCalculateWith = tr2
+				timeToCalculateWith = tr2.Status.CompletionTime.Time
+				break
+			}
+			ctrl.Log.V(4).Info(fmt.Sprintf("skipping %s as a gap candidate for current task %s is OK", taskRef(tr2.Labels), taskRef(tr.Labels)))
+		}
+		gapEntry.gap = float64(tr.CreationTimestamp.Time.Sub(timeToCalculateWith).Milliseconds())
+		gapEntry.completed = taskRef(trToCalculateWith.Labels)
+		gapEntry.upcoming = taskRef(tr.Labels)
+		gapEntries = append(gapEntries, gapEntry)
+	}
+	return gapEntries
+}
+
+func filter(numerator, denominator float64) bool {
+	// if overhead is non-zero, but total duration is less that 40 seconds,
+	// this is a simpler, most likely user defined pipeline which does not fall
+	// under our image building based overhead concerns
+	if numerator > 0 && denominator < 40000 {
+		return true
+	}
+	//TODO we don't have a sense for it yet, but at some point we may get an idea
+	// of what is unacceptable overhead regardless of total duration, where we don't
+	// try to mitigate the tekton controller and user pipelineruns sharing the same
+	// cluster resources
+	return false
 }


### PR DESCRIPTION
We seen periods with our overhead grafana panels where user defined pipelineruns with very short durations, but even the smallest bit of overhead (where some subsecond overhead could have rounded up to even 1 second), contaminated our overhead percentages.  Especially for the execution overhead query.

This commit does two things
- aggregates the multiple historgrams used to calculate metrics into one histogram; this will help with performance from the dashboard, especially on the app-sre dashboard, based on what I saw with executing our current queries there
- adds filter step as part of calcuating the new metric to not include these pipelineruns that are relatively much shorter than the RHTAP defined pipelines in build-definitions.

This work also includes some code reorganization so that I could share code between the existing gap metric and the new metrics.

