### PR TITLE
PLNSRVCE-1585: fix filtering of throttled pipelineruns form execution overhead metric 

### DIFF
--- a/collector/controller.go
+++ b/collector/controller.go
@@ -64,10 +64,6 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 	if err := pipelinev1.AddToScheme(options.Scheme); err != nil {
 		return nil, err
 	}
-	options.NewCache = cache.BuilderWithOptions(cache.Options{
-		SelectorsByObject: cache.SelectorsByObject{
-			&pipelinev1.PipelineRun{}: {},
-		}})
 
 	var mgr ctrl.Manager
 	var err error
@@ -79,6 +75,8 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 	}
 	podSelector := labels.NewSelector().Add(*labelReq)
 	selectors := cache.SelectorsByObject{
+		&pipelinev1.PipelineRun{}: {},
+		&pipelinev1.TaskRun{}:     {},
 		&corev1.Pod{}: cache.ObjectSelector{
 			Label: podSelector,
 		},

--- a/collector/pipelinerun_taskrun_complete_create_gaps_test.go
+++ b/collector/pipelinerun_taskrun_complete_create_gaps_test.go
@@ -246,7 +246,7 @@ func TestPipelineRunGapCollection_MissingTaskRuns(t *testing.T) {
 }
 
 func TestTaskRunGapEventFilter_Update(t *testing.T) {
-	filter := &taskRunGapEventFilter{}
+	filterObj := &taskRunGapEventFilter{}
 	for _, tc := range []struct {
 		name       string
 		oldPR      *v1.PipelineRun
@@ -340,7 +340,7 @@ func TestTaskRunGapEventFilter_Update(t *testing.T) {
 			ObjectOld: tc.oldPR,
 			ObjectNew: tc.newPR,
 		}
-		rc := filter.Update(ev)
+		rc := filterObj.Update(ev)
 		if rc != tc.expectedRC {
 			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
 		}


### PR DESCRIPTION
The changes from https://github.com/openshift-pipelines/pipeline-service-exporter/pull/52 did not in fact properly tag and then filter pipelineruns who experience throttling of their taskruns.  Most notably was the controller runtime filter excluded pipelineruns from the reconcilation there were not completed.  Also, the labeling was only occuring within the block that confirmed the pipelinerun completed.  The condition in fact wil only occur while things are running.

@openshift-pipelines/pipelines-service PTAL