### PR TITLE
PLNSRVCE-1585: more filter on throttle fixes

### DIFF
--- a/collector/overhead_alert_metrics_test.go
+++ b/collector/overhead_alert_metrics_test.go
@@ -40,12 +40,13 @@ func TestOverheadGapEventFilter_Update(t *testing.T) {
 		expectedRC bool
 	}{
 		{
-			name:  "not done no status",
-			oldPR: &v1.PipelineRun{},
-			newPR: &v1.PipelineRun{},
+			name:       "not done no status, no kids",
+			oldPR:      &v1.PipelineRun{},
+			newPR:      &v1.PipelineRun{},
+			expectedRC: true,
 		},
 		{
-			name:  "not done status unknown",
+			name:  "not done status unknown, still no kids",
 			oldPR: &v1.PipelineRun{},
 			newPR: &v1.PipelineRun{
 				Status: v1.PipelineRunStatus{
@@ -59,6 +60,7 @@ func TestOverheadGapEventFilter_Update(t *testing.T) {
 					},
 				},
 			},
+			expectedRC: true,
 		},
 		{
 			name:  "not done taskruns throttled on quota",
@@ -163,6 +165,25 @@ func TestOverheadGapEventFilter_Update(t *testing.T) {
 							{
 								TypeMeta: runtime.TypeMeta{Kind: "TaskRun"},
 								Name:     "taskrun1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "just done succeed but previously throttled",
+			oldPR: &v1.PipelineRun{},
+			newPR: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{THROTTLED_LABEL: "taskrun1"},
+				},
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{
+							{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
 							},
 						},
 					},


### PR DESCRIPTION
We finally had a throttling event in staging and still did not see the exporter filter and tag; so this time contrived some throttling events in a test cluster sorted out some edge case issues with the code around timings between taskrun updates and pipelinerun updates.

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED