### PR TITLE
clear out pvc namespace cache on reset

### DIFF
--- a/collector/throttled_by_pvc_count.go
+++ b/collector/throttled_by_pvc_count.go
@@ -123,6 +123,10 @@ func (r *ReconcilePVCThrottled) resetPVCStats(ctx context.Context) {
 	for ns := range r.nsCache {
 		r.prCollector.zeroPVCThrottle(ns)
 	}
+	// however, we'll clear out cache to avoid long term accumulation, memory leak, as things like dynamically created test clusters
+	// accumulate; as long as we maintain history for permanent, active tenant namespaces, that is OK
+	r.nsCache = map[string]struct{}{}
+
 	prList := &v1.PipelineRunList{}
 	err := r.client.List(ctx, prList)
 	nsWithPVCThrottle := map[string]struct{}{}


### PR DESCRIPTION
although it can be slow acting over many, many days, and plenty of GC is occurring in the exporter, the use of dynamically created namespace in our e2e's leads to slow growth in the pvc ns cache map, and I've seen exporter have to recycle because of hitting the mem limit about once a month; the effect is that stats for these ephemeral namespaces, or for tenants with long bouts of inactivity, will show up as 'no data', which for our purposes only needing this stat when there are live pvc quota issues calling in pipeline svc for support, is OK

@openshift-pipelines/pipelines-service FYI

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED