### PR TITLE
PLNSRVCE-1692: consolidate metrics into single pipelinerun, taskrun, pod controllers tuned for performance; convert pvc metric to poll only

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,9 @@ go run main.go
 ### Deployment
 The Pipeline Service Exporter is deployed as a separate service within the [Pipeline Service](https://github.com/openshift-pipelines/pipeline-service/tree/main/operator/gitops/argocd/pipeline-service/metrics-exporter) repository. The Deployment (built out of a container image created from the Dockerfile in this repo), Service and other resources required for it are present in that folder.
 
+One could use the pipeline-service `dev_setup.sh` script to do local development.  However, one could also simple run `oc apply -k` or `oc delete -k` against `operator/gitops/argocd/pipeline-service/metrics-exporter` when in your pipeline-service local clone of the repository.
+Just install the OpenShift Pipelines operator from the OCP console beforehand.  Build the image from the Dockerfile at the root of this repository, but push to your personal image registry repository.  Then update the `operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml` 
+to point to your image.  The image pull policy of the deployment is `IfNotPresent`, so just change the version tag of your image as you iterate.
+
 ### License
 The Pipeline Service Exporter is licensed under the Apache-2.0 license.

--- a/collector/utils_test.go
+++ b/collector/utils_test.go
@@ -17,8 +17,17 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"testing"
 )
+
+func unregisterStats(r *ExporterReconcile) {
+	metrics.Registry.Unregister(r.overheadCollector.execution)
+	metrics.Registry.Unregister(r.overheadCollector.scheduling)
+	metrics.Registry.Unregister(r.prGapCollector.trGaps)
+	metrics.Registry.Unregister(r.pvcCollector.pvcThrottle)
+
+}
 
 func validateHistogramVec(t *testing.T, h *prometheus.HistogramVec, labels prometheus.Labels, checkMax bool) {
 	observer, err := h.GetMetricWith(labels)

--- a/docs/metrics-specification.md
+++ b/docs/metrics-specification.md
@@ -5,13 +5,55 @@ This document outlines the specifications for a Prometheus exporter that collect
 
 ### Metrics Definition:
 
+_**PipelineRun Execution Overhead:**_  
+Proportion of time elapsed between the completion of a TaskRun and the start of the next TaskRun within a PipelineRun to the total duration of successful PipelineRuns.
+
+_Metric Name:_ `pipeline_service_execution_overhead_percentage`
+_Labels:_ `namespace`, `status` labels.
+_Data Type:_ Histogram
+_Description:_ One of our alert metrics, which we target to be 5% or below over the course of a day, across 28 days.
+
+_**PipelineRun Scheduling Overhead:**_  
+Proportion of time elapsed waiting for the pipeline controller to receive create events compared to the total duration of successful PipelineRuns.
+
+_Metric Name:_ `pipeline_service_schedule_overhead_percentage`
+_Labels:_ `namespace`, `status` labels.
+_Data Type:_ Histogram
+_Description:_ One of our alert metrics, which we target to be 5% or below over the course of a day, across 28 days.
+
+_**Pipeline Bundle Resolution Wait Time:**_  
+Duration in milliseconds for a resolution request for a pipeline reference needed by a pipelinerun to be recognized as complete by the pipelinerun reconciler in the tekton controller.
+
+_Metric Name:_ `pipelinerun_pipeline_resolution_wait_milliseconds`
+_Labels:_ `namespace`, `pipelinename` labels.
+_Data Type:_ Histogram
+_Description:_ Gives an indication on how long the pulling of the Konflux Pipeline Bundles form quay.io are taking,
+before the cache is established, when creating PipelineRuns.
+
+_**Task Bundle Resolution Wait Time:**_  
+Duration in milliseconds for a resolution request for a pipeline reference needed by a taskrun to be recognized as complete by the taskrun reconciler in the tekton controller.
+
+_Metric Name:_ `taskrun_task_resolution_wait_milliseconds`
+_Labels:_ `namespace`, `taskname` labels.
+_Data Type:_ Histogram
+_Description:_ Gives an indication on how long the pulling of the Konflux Task and Pipeline Bundles form quay.io are taking,
+before the cache is established, when creating TaskRuns.
+
+_**Underlying Pod Creation To Complete Times:**_  
+Since tekton's analogous duration metrics are only from start time to completion, we provide a create time to completion for comparisons and potential alerting.
+
+_Metric Name:_ `tekton_pods_create_to_complete_seconds`
+_Labels:_ `namespace`, `pipelinename`, `taskname` labels.
+_Data Type:_ Histogram
+_Description:_ A better alternative in our opinion to the upstream metric `tekton_pipelines_controller_pipelinerun_duration_seconds_[bucket, sum, count]`
+
 _**PipelineRun Failed With PVC Quota:**_  
 The count of the number of current PipelineRuns on the cluster marked failed by Tekton because PVC Quota prevented creation of required PVCs. 
 The deletion of PipelineRuns that failed because of PVC limits is effectively a decrement of the metric.  That said, given the complexities around
 delete events and controllers (missed events not getting relisted, hit and miss success of tombstone objects, multiple events because of finalizers),
 we do not decrement in real time, but on our custom Runnable that resets the metric at the same interval the TektonConfig pruner is set to.
 
-_Metric Name:_ pipelinerun_failed_by_pvc_quota_count
+_Metric Name:_ `pipelinerun_failed_by_pvc_quota_count`
 _Labels:_ `namespace` label.  Note:  K8s PVC quota specifications are a namespace scoped resource.
 _Data Type:_ Gauge
 _Description:_ The number of PipelineRuns marked failed because required PVCs could not be created.
@@ -19,7 +61,7 @@ _Description:_ The number of PipelineRuns marked failed because required PVCs co
 _**PipelineRun Scheduling Duration:**_  
 The duration of time in seconds taken for a PipelineRun to be "scheduled", meaning it has been received by the Tekton controller.  It is calculated as the difference between the creation timestamp and the start time of the PipelineRun, where the start time is set by the Tekton controller on the initial event received for the creation of the PipelineRun.  It is a good indication of how quickly the API server sends create events to the Tekton controller.
 
-_Metric Name:_ pipelinerun_duration_scheduled_seconds
+_Metric Name:_ `pipelinerun_duration_scheduled_seconds`
 _Labels:_ a `namespace` label and the `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.
 _Data Type:_ Histogram
 _Description:_ The time taken in seconds for a PipelineRun to be "scheduled", meaning it has been received by the Tekton controller.
@@ -27,7 +69,7 @@ _Description:_ The time taken in seconds for a PipelineRun to be "scheduled", me
 _**TaskRun Scheduling Duration:**_  
 The duration of time in seconds taken for a TaskRun to be "scheduled", meaning it has been received by the Tekton controller.  It is calculated as the difference between the creation timestamp and the start time of the TaskRun, where the start time is set by the Tekton controller on the initial event received for the creation of the TaskRun.  It is a good indication of how quickly the API server sends create events to the Tekton controller.
 
-_Metric Name:_ taskrun_duration_scheduled_seconds
+_Metric Name:_ `taskrun_duration_scheduled_seconds`
 _Labels:_ a `namespace` label and the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
 _Data Type:_ Histogram
 _Description:_ The time taken in seconds for a TaskRun to be "scheduled", meaning it has been received by the Tekton controller.
@@ -36,7 +78,7 @@ _Description:_ The time taken in seconds for a TaskRun to be "scheduled", meanin
 _**Scheduling Duration of different TaskRuns with a PipelineRun:**_
 The time taken in milliseconds between the creation of the first TaskRun(s) and the creation of its PipelineRun, followed by the duration in milliseconds between the completion of a preceding TaskRun and the creation of the following TaskRun.  This metrics accounts for both sequential TaskRuns, parallel TaskRuns that start off a PipelineRun, and ending TaskRuns that depend on multiple TaskRun chains that run in parallel.
 
-_Metric Name:_ pipelinerun_gap_between_taskruns_milliseconds
+_Metric Name:_ `pipelinerun_gap_between_taskruns_milliseconds`
 _Labels:_ Minimally a `namespace` label.  If the `ENABLE_GAP_METRIC_ADDITIONAL_LABELS` environment variable is set to `true` on the exporter deployment, the `pipelinename`, `completed`, and `upcoming` labels are set.  The `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.  The `completed` label is set either the Pipeline name if we are dealing with the first TaskRun, or the name of the latest Task for the TaskRun to be completed.  The `upcoming` label is set to the name of the Task of the TaskRun that is created but not yet complete.
 _Data Type_: Histogram
 _Description_: The taken between TaskRuns within a PipelineRun
@@ -44,8 +86,7 @@ _Description_: The taken between TaskRuns within a PipelineRun
 _**Scheduling Duration that a TaskRun Pod is recognized by the Kubelet:**_
 The time taken in milliseconds between the creation of a Pod, where the Pod start time is set once the kubelet has acknowledged the pod, but has not yet pulled its images.
 
-
-_Metric Name:_ taskrun_pod_duration_kubelet_acknowledged_milliseconds
+_Metric Name:_ `taskrun_pod_duration_kubelet_acknowledged_milliseconds`
 _Labels:_ a `namespace` label and the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
 _Data Type_: Histogram
 _Description_: Duration in milliseconds between the pod creation time and pod start time
@@ -53,8 +94,7 @@ _Description_: Duration in milliseconds between the pod creation time and pod st
 _**Scheduling Duration that a TaskRun Pod's images are pulled by the Kubelet and the Pod is started:**_
 The time taken in milliseconds between the pod start time and the first container to start. This should include any overhead to pull container images, plus any kubelet to linux scheduling overhead.
 
-
-_Metric Name:_ taskrun_pod_duration_kubelet_acknowledged_milliseconds
+_Metric Name:_ `taskrun_pod_duration_kubelet_to_container_start_milliseconds`
 _Labels:_ a `namespace` label and the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
 _Data Type_: Histogram
 _Description_: Duration in milliseconds between the pod start time and the first container to start.

--- a/main.go
+++ b/main.go
@@ -72,6 +72,8 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = 50
+	restConfig.Burst = 50
 	var mgr ctrl.Manager
 	var err error
 	mopts := ctrl.Options{


### PR DESCRIPTION
As part of getting ready to add the 'no pod create attempts occuring for pipelineruns' metric for satisfying AppSRE/Infra feedback on core tekton health, I've been monitoring the memory usage on prod-r01 and the previous "simpler" approach of creating controllers per replicas may be now proving untenable. As konflux onboading increases, exporter's memory usage continues to grow, and I've had to increase the memory limit from 1G to 3G just in the last few weeks.

Note, the consolidating metrics into common reconcilers made the PVC gauge metric utilizing a reconciler in addition to the existing poller (a la what upstream does) untenable.  Hence we now just leverage the polling thread for the PVC metric.

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED

@enarha @jkhelil PTAL

@jkhelil your github ID does not show up as a reviewer.  My guess is there is some github related onboarding activity you still have to do, though I'm not sure what it is exactly.  See if you can find it in the onboarding doc, or maybe see if Romain knows. 