### PR TITLE
PLNSRVCE-1692: add metric to determine if the core controller is not attempting to create underlying pods

### DIFF
--- a/collector/throttled_by_pvc_count.go
+++ b/collector/throttled_by_pvc_count.go
@@ -9,32 +9,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"strings"
-	"time"
 )
 
 type ThrottledByPVCQuotaCollector struct {
 	pvcThrottle *prometheus.GaugeVec
-}
-
-// Start - we do a long running runnable to reset the pvc metric in case we miss delete events, as controller relist does not duplicate
-// delete events like it can create/update events
-func (r *ExporterReconcile) Start(ctx context.Context) error {
-	//this matches the scheduling interval for pruner in the operator's TektonConfig object
-	//for now we are going to refrain from reading in the TektonConfig, bringing in a 3rd party
-	// golang cronjob schedule parser, and pulling the value; but if we end up changing it with
-	// some frequency, we'll start doing that
-	eventTicker := time.NewTicker(2 * time.Minute)
-	for {
-		select {
-		case <-eventTicker.C:
-			r.resetPVCStats(ctx)
-		case <-ctx.Done():
-			controllerLog.Info("ReconcilePVCThrottled Runnable context is marked as done, exiting")
-			eventTicker.Stop()
-			return nil
-		}
-	}
-	return nil
 }
 
 func failedBecauseOfPVCQuota(pr *v1.PipelineRun) bool {
@@ -52,23 +30,19 @@ func failedBecauseOfPVCQuota(pr *v1.PipelineRun) bool {
 }
 
 func (r *ExporterReconcile) resetPVCStats(ctx context.Context) {
-	// originally considered using pvcThrottle.Reset() but wanted to allow for history based searches from metrics
-	// console, so we are trying keeping track of namespaces; for now, not worried about history across exporter restart
-	for ns := range r.nsCache {
-		r.pvcCollector.zeroPVCThrottle(ns)
-	}
+	innerReset(r.pvcCollector, r.pvcNSCache)
 	// however, we'll clear out cache to avoid long term accumulation, memory leak, as things like dynamically created test clusters
 	// accumulate; as long as we maintain history for permanent, active tenant namespaces, that is OK
-	r.nsCache = map[string]struct{}{}
+	r.pvcNSCache = map[string]struct{}{}
 
 	prList := &v1.PipelineRunList{}
 	err := r.client.List(ctx, prList)
 	nsWithPVCThrottle := map[string]struct{}{}
 	if err == nil {
 		for _, pr := range prList.Items {
-			r.nsCache[pr.Namespace] = struct{}{}
+			r.pvcNSCache[pr.Namespace] = struct{}{}
 			if failedBecauseOfPVCQuota(&pr) {
-				r.pvcCollector.incPVCThrottle(&pr)
+				r.pvcCollector.IncCollector(pr.Namespace)
 				nsWithPVCThrottle[pr.Namespace] = struct{}{}
 				continue
 			}
@@ -80,7 +54,7 @@ func (r *ExporterReconcile) resetPVCStats(ctx context.Context) {
 			if ok {
 				continue
 			}
-			r.pvcCollector.zeroPVCThrottle(pr.Namespace)
+			r.pvcCollector.ZeroCollector(pr.Namespace)
 		}
 	}
 }
@@ -125,12 +99,12 @@ func NewPVCThrottledCollector() *ThrottledByPVCQuotaCollector {
 	return pvcThrottledCollector
 }
 
-func (c *ThrottledByPVCQuotaCollector) incPVCThrottle(pr *v1.PipelineRun) {
-	labels := map[string]string{NS_LABEL: pr.Namespace}
+func (c *ThrottledByPVCQuotaCollector) IncCollector(ns string) {
+	labels := map[string]string{NS_LABEL: ns}
 	c.pvcThrottle.With(labels).Inc()
 }
 
-func (c *ThrottledByPVCQuotaCollector) zeroPVCThrottle(ns string) {
+func (c *ThrottledByPVCQuotaCollector) ZeroCollector(ns string) {
 	labels := map[string]string{NS_LABEL: ns}
 	c.pvcThrottle.With(labels).Set(float64(0))
 }

--- a/collector/utils_test.go
+++ b/collector/utils_test.go
@@ -26,6 +26,7 @@ func unregisterStats(r *ExporterReconcile) {
 	metrics.Registry.Unregister(r.overheadCollector.scheduling)
 	metrics.Registry.Unregister(r.prGapCollector.trGaps)
 	metrics.Registry.Unregister(r.pvcCollector.pvcThrottle)
+	metrics.Registry.Unregister(r.waitPodCollector.waitPodCreate)
 
 }
 

--- a/collector/waiting_on_pod_create_attempt.go
+++ b/collector/waiting_on_pod_create_attempt.go
@@ -1,0 +1,91 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+type WaitingOnPodCreateAttemptCollector struct {
+	waitPodCreate *prometheus.GaugeVec
+}
+
+func NewWaitingOnPodCreateAttemptCollector() *WaitingOnPodCreateAttemptCollector {
+	labelNames := []string{NS_LABEL}
+	waitPodCreate := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "taskrun_pod_create_not_attempted_count",
+		Help: "Number of TaskRuns where the Tekton Controller has yet to attempt to create its underlying Pod",
+	}, labelNames)
+	waitPodCreateCollector := &WaitingOnPodCreateAttemptCollector{
+		waitPodCreate: waitPodCreate,
+	}
+	metrics.Registry.Register(waitPodCreate)
+	return waitPodCreateCollector
+}
+
+func (c *WaitingOnPodCreateAttemptCollector) IncCollector(ns string) {
+	labels := map[string]string{NS_LABEL: ns}
+	c.waitPodCreate.With(labels).Inc()
+}
+
+func (c *WaitingOnPodCreateAttemptCollector) ZeroCollector(ns string) {
+	labels := map[string]string{NS_LABEL: ns}
+	c.waitPodCreate.With(labels).Set(float64(0))
+}
+
+func attemptedToCreatePod(tr *v1.TaskRun) bool {
+	if len(tr.Status.PodName) > 0 {
+		return true
+	}
+	// see if the success condition has been handled by either TaskRunStatus.MarkResourceFailed
+	// or TaskRunStatus.MarkReasonOngoing, which are the two methods called in the TaskRun reconciler
+	// when handling pod create errors
+
+	// failure will result in IsDone being
+	if tr.IsDone() {
+		controllerLog.Info("GGM is done")
+		return true
+	}
+
+	// reason and message will be set when MarkReasonOngoing called
+	con := tr.Status.GetCondition(apis.ConditionSucceeded)
+	if con != nil &&
+		con.Status == corev1.ConditionUnknown &&
+		len(con.Reason) > 0 &&
+		len(con.Message) > 0 {
+		return true
+	}
+	controllerLog.Info(fmt.Sprintf("no pod creation yet for %s:%s", tr.Namespace, tr.Name))
+	return false
+}
+
+func (r *ExporterReconcile) resetPodCreateAttemptedStats(ctx context.Context) {
+	innerReset(r.pvcCollector, r.waitPodNSCache)
+	// however, we'll clear out cache to avoid long term accumulation, memory leak, as things like dynamically created test clusters
+	// accumulate; as long as we maintain history for permanent, active tenant namespaces, that is OK
+	r.waitPodNSCache = map[string]struct{}{}
+
+	trList := &v1.TaskRunList{}
+	err := r.client.List(ctx, trList)
+	nsWithWaitOnPod := map[string]struct{}{}
+	if err == nil {
+		for _, tr := range trList.Items {
+			r.waitPodNSCache[tr.Namespace] = struct{}{}
+			if !attemptedToCreatePod(&tr) {
+				r.waitPodCollector.IncCollector(tr.Namespace)
+				nsWithWaitOnPod[tr.Namespace] = struct{}{}
+				continue
+			}
+
+			_, ok := nsWithWaitOnPod[tr.Namespace]
+			if ok {
+				continue
+			}
+			r.waitPodCollector.ZeroCollector(tr.Namespace)
+		}
+	}
+}

--- a/collector/waiting_on_pod_create_attempt_test.go
+++ b/collector/waiting_on_pod_create_attempt_test.go
@@ -1,0 +1,113 @@
+package collector
+
+import (
+	"context"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestResetPodCreateAttemptedStats(t *testing.T) {
+	objs := []client.Object{}
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	mockTaskRuns := []*v1.TaskRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-1"},
+			Status: v1.TaskRunStatus{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					PodName: "test-1-pod",
+				},
+			},
+		},
+		// should bump the counter
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-2"},
+			Status:     v1.TaskRunStatus{},
+		},
+		// should bump the counter
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-3"},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						apis.Condition{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionUnknown,
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-4"},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						apis.Condition{
+							Type:    apis.ConditionSucceeded,
+							Status:  corev1.ConditionUnknown,
+							Reason:  "foo",
+							Message: "bar",
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-5"},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						apis.Condition{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-6"},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						apis.Condition{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := context.TODO()
+	for _, pr := range mockTaskRuns {
+		err := c.Create(ctx, pr)
+		assert.NoError(t, err)
+	}
+
+	reconciler := buildReconciler(c, nil, nil)
+	reconciler.resetPodCreateAttemptedStats(ctx)
+	label := prometheus.Labels{NS_LABEL: "test-namespace"}
+	validateGaugeVec(t, reconciler.waitPodCollector.waitPodCreate, label, float64(2))
+	// second pass should reset and still be two
+	reconciler.resetPodCreateAttemptedStats(ctx)
+	validateGaugeVec(t, reconciler.waitPodCollector.waitPodCreate, label, float64(2))
+	// deletion, then another pass, should now be one
+	err := c.Delete(ctx, mockTaskRuns[1])
+	assert.NoError(t, err)
+	reconciler.resetPodCreateAttemptedStats(ctx)
+	validateGaugeVec(t, reconciler.waitPodCollector.waitPodCreate, label, float64(1))
+	unregisterStats(reconciler)
+}

--- a/docs/metrics-specification.md
+++ b/docs/metrics-specification.md
@@ -58,6 +58,14 @@ _Labels:_ `namespace` label.  Note:  K8s PVC quota specifications are a namespac
 _Data Type:_ Gauge
 _Description:_ The number of PipelineRuns marked failed because required PVCs could not be created.
 
+_**TaskRun Yet To Attempt Pod Creation:**_  
+The number of TaskRuns where the Tekton Controller has yet to attempt to create its underlying Pod.
+
+_Metric Name:_ `taskrun_pod_create_not_attempted_count`
+_Labels:_ `namespace` label.  
+_Data Type:_ Gauge
+_Description:_ The number of TaskRuns where the Tekton Controller has yet to attempt to create its underlying Pod.
+
 _**PipelineRun Scheduling Duration:**_  
 The duration of time in seconds taken for a PipelineRun to be "scheduled", meaning it has been received by the Tekton controller.  It is calculated as the difference between the creation timestamp and the start time of the PipelineRun, where the start time is set by the Tekton controller on the initial event received for the creation of the PipelineRun.  It is a good indication of how quickly the API server sends create events to the Tekton controller.
 


### PR DESCRIPTION
While the current execution overhead metric can indicate that the core Tekton controllers are struggling, it is not a definitive declaration that the controller is deadlocked.

Ultimately, Tekton is deadlocked if the TaskRun is not in terminal state, but it has not even attempted to create the underlying Pod.

End of the day, Tekton core controller needs to create Pods from the higher level abstraction API to run the user's Pipelines.

We add the metric to capture this with this PR.

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED