### PR TITLE
remove task/pipeline labels as they can correspod to run names

### DIFF
--- a/collector/controller.go
+++ b/collector/controller.go
@@ -229,7 +229,6 @@ type ExporterReconcile struct {
 	scheme                            *runtime.Scheme
 	eventRecorder                     record.EventRecorder
 	overheadCollector                 *OverheadCollector
-	gapAdditionalLabels               bool
 	prGapCollector                    *PipelineRunTaskRunGapCollector
 	trGaps                            *prometheus.HistogramVec
 	pvcNSCache                        map[string]struct{}
@@ -249,7 +248,6 @@ func buildReconciler(client client.Client, scheme *runtime.Scheme, eventRecorder
 		scheme:                   scheme,
 		eventRecorder:            eventRecorder,
 		overheadCollector:        NewOverheadCollector(),
-		gapAdditionalLabels:      prTrGapCollector.additionalLabels,
 		prGapCollector:           prTrGapCollector,
 		trGaps:                   prTrGapCollector.trGaps,
 		pvcNSCache:               map[string]struct{}{},

--- a/collector/pipeline_reference_wait_time.go
+++ b/collector/pipeline_reference_wait_time.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewPipelineReferenceWaitTimeMetric() *prometheus.HistogramVec {
-	labelNames := []string{NS_LABEL, PIPELINE_NAME_LABEL}
+	labelNames := []string{NS_LABEL}
 	waitMetric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "pipelinerun_pipeline_resolution_wait_milliseconds",
 		Help:    "Duration in milliseconds for a resolution request for a pipeline reference needed by a pipelinerun to be recognized as complete by the pipelinerun reconciler in the tekton controller. ",
@@ -54,7 +54,7 @@ func (f *pipelineRefWaitTimeFilter) Update(e event.UpdateEvent) bool {
 		if !oldPR.IsDone() && newPR.IsDone() {
 			// if we did not use some sort of resolve, set metric to 0
 			if newPR.Spec.PipelineRef == nil {
-				labels := map[string]string{NS_LABEL: newPR.Namespace, PIPELINE_NAME_LABEL: pipelineRef(newPR.Labels)}
+				labels := map[string]string{NS_LABEL: newPR.Namespace}
 				f.waitDuration.With(labels).Observe(float64(0))
 			}
 		}
@@ -69,7 +69,7 @@ func (f *pipelineRefWaitTimeFilter) Update(e event.UpdateEvent) bool {
 		newReason := newSucceedCondition.Reason
 		// wrt direct string reference, waiting for tag/release with constant moved to the api package
 		if oldReason == "ResolvingPipelineRef" && newReason != "ResolvingPipelineRef" {
-			labels := map[string]string{NS_LABEL: newPR.Namespace, PIPELINE_NAME_LABEL: pipelineRef(newPR.Labels)}
+			labels := map[string]string{NS_LABEL: newPR.Namespace}
 			originalTime := oldSucceedCondtition.LastTransitionTime.Inner
 			f.waitDuration.With(labels).Observe(float64(newSucceedCondition.LastTransitionTime.Inner.Sub(originalTime.Time).Milliseconds()))
 			return false

--- a/collector/pipeline_reference_wait_time_test.go
+++ b/collector/pipeline_reference_wait_time_test.go
@@ -135,7 +135,7 @@ func TestPipelineRefWaitTimeFilter_Update(t *testing.T) {
 		if rc != tc.expectedRC {
 			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
 		}
-		labels := prometheus.Labels{NS_LABEL: tc.newPR.Namespace, PIPELINE_NAME_LABEL: pipelineRef(tc.newPR.Labels)}
+		labels := prometheus.Labels{NS_LABEL: tc.newPR.Namespace}
 		if tc.expectedNonZeroMetric {
 			validateHistogramVec(t, filter.waitDuration, labels, false)
 		} else {

--- a/collector/pipelinerun_create_to_start_time.go
+++ b/collector/pipelinerun_create_to_start_time.go
@@ -14,7 +14,7 @@ type PipelineRunScheduledCollector struct {
 }
 
 func NewPipelineRunScheduledMetric() *prometheus.HistogramVec {
-	labelNames := []string{NS_LABEL, PIPELINE_NAME_LABEL, STATUS_LABEL}
+	labelNames := []string{NS_LABEL, STATUS_LABEL}
 	durationScheduled := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "pipelinerun_duration_scheduled_seconds",
 		Help: "Duration in seconds for a PipelineRun to be 'scheduled', meaning it has been received by the Tekton controller.  This is an indication of how quickly create events from the API server are arriving to the Tekton controller.",
@@ -34,7 +34,7 @@ func bumpPipelineRunScheduledDuration(scheduleDuration float64, pr *v1.PipelineR
 	if succeededCondition.IsFalse() {
 		status = FAILED
 	}
-	labels := map[string]string{NS_LABEL: pr.Namespace, PIPELINE_NAME_LABEL: pipelineRunPipelineRef(pr), STATUS_LABEL: status}
+	labels := map[string]string{NS_LABEL: pr.Namespace, STATUS_LABEL: status}
 	metric.With(labels).Observe(scheduleDuration)
 }
 

--- a/collector/pipelinerun_create_to_start_time_test.go
+++ b/collector/pipelinerun_create_to_start_time_test.go
@@ -171,7 +171,7 @@ func TestPipelineRunScheduleCollection(t *testing.T) {
 	}
 	for _, pr := range mockPipelineRuns {
 		metric := NewPipelineRunScheduledMetric()
-		label := prometheus.Labels{NS_LABEL: "test-namespace", PIPELINE_NAME_LABEL: pipelineRunPipelineRef(pr), STATUS_LABEL: SUCCEEDED}
+		label := prometheus.Labels{NS_LABEL: "test-namespace", STATUS_LABEL: SUCCEEDED}
 		bumpPipelineRunScheduledDuration(calculateScheduledDurationPipelineRun(pr), pr, metric)
 		validateHistogramVec(t, metric, label, false)
 		metrics.Registry.Unregister(metric)

--- a/collector/pod_create_to_complete_time.go
+++ b/collector/pod_create_to_complete_time.go
@@ -8,7 +8,7 @@ import (
 )
 
 func NewPodCreateToCompleteMetric() *prometheus.HistogramVec {
-	labelNames := []string{NS_LABEL, PIPELINE_NAME_LABEL, TASK_NAME_LABEL}
+	labelNames := []string{NS_LABEL}
 	c2cMetric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "tekton_pods_create_to_complete_seconds",
 		Help: "Since tekton's duration are only from start time to completion, we provide a create time to completion for comparisons and potential alerting",
@@ -66,7 +66,7 @@ func (f *podCreateToCompleteFilter) Update(e event.UpdateEvent) bool {
 
 		// if first transition when old pod still had non-terminated containers, but the new pod does not, process
 		if oldTerminatedState == nil && newTerminatedState != nil {
-			labels := map[string]string{NS_LABEL: newpod.Namespace, PIPELINE_NAME_LABEL: pipelineRef(newpod.Labels), TASK_NAME_LABEL: taskRef(newpod.Labels)}
+			labels := map[string]string{NS_LABEL: newpod.Namespace}
 			// we've seen in staging, especially with errors and short durations, and corroborated by comments I see in tekton,
 			// where it is conceivable node times are not synchronized, when controller has been scheduled to other nodes than the pods, weird timestamps, etc.
 			// so we check

--- a/collector/pod_create_to_complete_time_test.go
+++ b/collector/pod_create_to_complete_time_test.go
@@ -253,7 +253,7 @@ func TestPodCreateToCompleteFilter_Update(t *testing.T) {
 		if rc != tc.expectedRC {
 			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
 		}
-		labels := prometheus.Labels{NS_LABEL: tc.new.Namespace, PIPELINE_NAME_LABEL: pipelineRef(tc.new.Labels), TASK_NAME_LABEL: taskRef(tc.new.Labels)}
+		labels := prometheus.Labels{NS_LABEL: tc.new.Namespace}
 		if tc.expectedNonZeroMetric {
 			validateHistogramVec(t, filter.duration, labels, false)
 		} else {

--- a/collector/pod_create_to_kubelet_ack_time.go
+++ b/collector/pod_create_to_kubelet_ack_time.go
@@ -33,7 +33,7 @@ is "perhaps" the sum of those two
 */
 
 func NewPodCreateToKubeletDurationMetric() *prometheus.HistogramVec {
-	labelNames := []string{NS_LABEL, TASK_NAME_LABEL}
+	labelNames := []string{NS_LABEL}
 	metric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "taskrun_pod_duration_kubelet_acknowledged_milliseconds",
 		Help:    "Duration in milliseconds between the pod creation time and pod start time, where the pod start time is set once the kubelet has acknowledged the pod, but has not yet pulled its images.",
@@ -65,7 +65,7 @@ func (f *createKubeletLatencyFilter) Update(e event.UpdateEvent) bool {
 	newpod, oknew := e.ObjectNew.(*corev1.Pod)
 	if okold && oknew {
 		if oldpod.Status.StartTime == nil && newpod.Status.StartTime != nil {
-			labels := map[string]string{NS_LABEL: newpod.Namespace, TASK_NAME_LABEL: taskRef(newpod.Labels)}
+			labels := map[string]string{NS_LABEL: newpod.Namespace}
 			f.metric.With(labels).Observe(calculateTaskRunPodCreatedToKubeletAcceptsAndStartTimeSetDuration(newpod))
 			return false
 		}

--- a/collector/pod_create_to_kubelet_ack_time_test.go
+++ b/collector/pod_create_to_kubelet_ack_time_test.go
@@ -53,7 +53,7 @@ func TestCreateKubeletLatencyFilter_Update(t *testing.T) {
 			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
 		}
 		if tc.expectedMetric {
-			validateHistogramVec(t, filter.metric, prometheus.Labels{NS_LABEL: tc.newPod.Namespace, TASK_NAME_LABEL: taskRef(tc.newPod.Labels)}, false)
+			validateHistogramVec(t, filter.metric, prometheus.Labels{NS_LABEL: tc.newPod.Namespace}, false)
 		}
 	}
 }

--- a/collector/pod_kubelet_ack_to_container_start_time.go
+++ b/collector/pod_kubelet_ack_to_container_start_time.go
@@ -34,7 +34,7 @@ is "perhaps" the sum of those two
 */
 
 func NewPodKubeletToContainerStartDurationMetric() *prometheus.HistogramVec {
-	labelNames := []string{NS_LABEL, TASK_NAME_LABEL}
+	labelNames := []string{NS_LABEL}
 	metric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "taskrun_pod_duration_kubelet_to_container_start_milliseconds",
 		Help:    "Duration in milliseconds between the pod start time and the first container to start. This should include any overhead to pull container images, plus any kubelet to linux scheduling overhead.",
@@ -69,7 +69,7 @@ func (f *kubeletContainerLatencyFilter) Update(e event.UpdateEvent) bool {
 	oldpod, okold := e.ObjectOld.(*corev1.Pod)
 	newpod, oknew := e.ObjectNew.(*corev1.Pod)
 	if okold && oknew {
-		labels := map[string]string{NS_LABEL: newpod.Namespace, TASK_NAME_LABEL: taskRef(newpod.Labels)}
+		labels := map[string]string{NS_LABEL: newpod.Namespace}
 
 		if oldpod.Status.StartTime == nil && newpod.Status.StartTime == nil {
 			return false

--- a/collector/pod_kubelet_ack_to_container_start_time_test.go
+++ b/collector/pod_kubelet_ack_to_container_start_time_test.go
@@ -143,7 +143,7 @@ func TestKubeletContainerLatencyFilter_Update(t *testing.T) {
 			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
 		}
 		if tc.expectedMetric {
-			validateHistogramVec(t, filter.metric, prometheus.Labels{NS_LABEL: tc.newPod.Namespace, TASK_NAME_LABEL: taskRef(tc.newPod.Labels)}, false)
+			validateHistogramVec(t, filter.metric, prometheus.Labels{NS_LABEL: tc.newPod.Namespace}, false)
 		}
 	}
 }

--- a/collector/task_reference_wait_time.go
+++ b/collector/task_reference_wait_time.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewTaskReferenceWaitTimeMetric() *prometheus.HistogramVec {
-	labelNames := []string{NS_LABEL, TASK_NAME_LABEL}
+	labelNames := []string{NS_LABEL}
 	waitMetric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "taskrun_task_resolution_wait_milliseconds",
 		Help:    "Duration in milliseconds for a resolution request for a task reference needed by a taskrun to be recognized as complete by the taskrun reconciler in the tekton controller. ",
@@ -55,7 +55,7 @@ func (f *taskRefWaitTimeFilter) Update(e event.UpdateEvent) bool {
 		if !oldTR.IsDone() && newTR.IsDone() {
 			// if we did not use some sort of resolve, set metric to 0
 			if newTR.Spec.TaskRef == nil {
-				labels := map[string]string{NS_LABEL: newTR.Namespace, TASK_NAME_LABEL: taskRef(newTR.Labels)}
+				labels := map[string]string{NS_LABEL: newTR.Namespace}
 				f.waitDuration.With(labels).Observe(float64(0))
 			}
 			return false
@@ -70,7 +70,7 @@ func (f *taskRefWaitTimeFilter) Update(e event.UpdateEvent) bool {
 		oldReason := oldSucceedCondtition.Reason
 		newReason := newSucceedCondition.Reason
 		if oldReason == v1.TaskRunReasonResolvingTaskRef && newReason != v1.TaskRunReasonResolvingTaskRef {
-			labels := map[string]string{NS_LABEL: newTR.Namespace, TASK_NAME_LABEL: taskRef(newTR.Labels)}
+			labels := map[string]string{NS_LABEL: newTR.Namespace}
 			originalTime := oldSucceedCondtition.LastTransitionTime.Inner
 			f.waitDuration.With(labels).Observe(float64(newSucceedCondition.LastTransitionTime.Inner.Sub(originalTime.Time).Milliseconds()))
 			return false

--- a/collector/task_reference_wait_time_test.go
+++ b/collector/task_reference_wait_time_test.go
@@ -135,7 +135,7 @@ func TestTaskRefWaitTimeFilter_Update(t *testing.T) {
 		if rc != tc.expectedRC {
 			t.Errorf(fmt.Sprintf("tc %s expected %v but got %v", tc.name, tc.expectedRC, rc))
 		}
-		labels := prometheus.Labels{NS_LABEL: tc.newTR.Namespace, TASK_NAME_LABEL: taskRef(tc.newTR.Labels)}
+		labels := prometheus.Labels{NS_LABEL: tc.newTR.Namespace}
 		if tc.expectedNonZeroMetric {
 			validateHistogramVec(t, filter.waitDuration, labels, false)
 		} else {

--- a/collector/taskrun_create_to_start_time.go
+++ b/collector/taskrun_create_to_start_time.go
@@ -34,7 +34,7 @@ is "perhaps" the sum of those two
 */
 
 func NewTaskRunScheduledMetric() *prometheus.HistogramVec {
-	labelNames := []string{NS_LABEL, TASK_NAME_LABEL, STATUS_LABEL}
+	labelNames := []string{NS_LABEL, STATUS_LABEL}
 	durationScheduled := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "taskrun_duration_scheduled_seconds",
 		Help: "Duration in seconds for a TaskRun to be 'scheduled', meaning it has been received by the Tekton controller.  This is an indication of how quickly create events from the API server are arriving to the Tekton controller.",
@@ -84,7 +84,7 @@ func bumpTaskRunScheduledDuration(scheduleDuration float64, tr *v1.TaskRun, metr
 	if succeedCondition.IsFalse() {
 		status = FAILED
 	}
-	labels := map[string]string{NS_LABEL: tr.Namespace, TASK_NAME_LABEL: taskRef(tr.Labels), STATUS_LABEL: status}
+	labels := map[string]string{NS_LABEL: tr.Namespace, STATUS_LABEL: status}
 	metric.With(labels).Observe(scheduleDuration)
 }
 

--- a/collector/taskrun_create_to_start_time_test.go
+++ b/collector/taskrun_create_to_start_time_test.go
@@ -135,7 +135,7 @@ func TestTaskRunScheduledCollection(t *testing.T) {
 
 	for _, tr := range mockTaskRuns {
 		metric := NewTaskRunScheduledMetric()
-		label := prometheus.Labels{NS_LABEL: "test-namespace", TASK_NAME_LABEL: taskRef(tr.Labels), STATUS_LABEL: SUCCEEDED}
+		label := prometheus.Labels{NS_LABEL: "test-namespace", STATUS_LABEL: SUCCEEDED}
 		bumpTaskRunScheduledDuration(calculateScheduledDurationTaskRun(tr), tr, metric)
 		validateHistogramVec(t, metric, label, false)
 		metrics.Registry.Unregister(metric)

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -37,19 +37,15 @@ import (
 )
 
 const (
-	FILTER_THRESHOLD                    = "FILTER_THRESHOLD"
-	DEFAULT_THRESHOLD                   = float64(300000) // 5 minutes in milliseconds
-	ALERT_RATIO                         = float64(0.05)
-	ENABLE_GAP_METRIC_ADDITIONAL_LABELS = "ENABLE_GAP_METRIC_ADDITIONAL_LABELS"
-	NS_LABEL                            = "namespace"
-	PIPELINE_NAME_LABEL                 = "pipelinename"
-	TASK_NAME_LABEL                     = "taskname"
-	COMPLETED_LABEL                     = "completed"
-	UPCOMING_LABEL                      = "upcoming"
-	STATUS_LABEL                        = "status"
-	SUCCEEDED                           = "succeded"
-	FAILED                              = "failed"
-	THROTTLED_LABEL                     = "pipelineservice.appstudio.io/throttled"
+	FILTER_THRESHOLD  = "FILTER_THRESHOLD"
+	DEFAULT_THRESHOLD = float64(300000) // 5 minutes in milliseconds
+	ALERT_RATIO       = float64(0.05)
+	NS_LABEL          = "namespace"
+	TASK_NAME_LABEL   = "taskname"
+	STATUS_LABEL      = "status"
+	SUCCEEDED         = "succeded"
+	FAILED            = "failed"
+	THROTTLED_LABEL   = "pipelineservice.appstudio.io/throttled"
 )
 
 func pipelineRunPipelineRef(pr *v1.PipelineRun) string {

--- a/docs/metrics-specification.md
+++ b/docs/metrics-specification.md
@@ -25,7 +25,7 @@ _**Pipeline Bundle Resolution Wait Time:**_
 Duration in milliseconds for a resolution request for a pipeline reference needed by a pipelinerun to be recognized as complete by the pipelinerun reconciler in the tekton controller.
 
 _Metric Name:_ `pipelinerun_pipeline_resolution_wait_milliseconds`
-_Labels:_ `namespace`, `pipelinename` labels.
+_Labels:_ `namespace`  label.
 _Data Type:_ Histogram
 _Description:_ Gives an indication on how long the pulling of the Konflux Pipeline Bundles form quay.io are taking,
 before the cache is established, when creating PipelineRuns.
@@ -34,7 +34,7 @@ _**Task Bundle Resolution Wait Time:**_
 Duration in milliseconds for a resolution request for a pipeline reference needed by a taskrun to be recognized as complete by the taskrun reconciler in the tekton controller.
 
 _Metric Name:_ `taskrun_task_resolution_wait_milliseconds`
-_Labels:_ `namespace`, `taskname` labels.
+_Labels:_ `namespace` label.
 _Data Type:_ Histogram
 _Description:_ Gives an indication on how long the pulling of the Konflux Task and Pipeline Bundles form quay.io are taking,
 before the cache is established, when creating TaskRuns.
@@ -43,7 +43,7 @@ _**Underlying Pod Creation To Complete Times:**_
 Since tekton's analogous duration metrics are only from start time to completion, we provide a create time to completion for comparisons and potential alerting.
 
 _Metric Name:_ `tekton_pods_create_to_complete_seconds`
-_Labels:_ `namespace`, `pipelinename`, `taskname` labels.
+_Labels:_ `namespace` label.
 _Data Type:_ Histogram
 _Description:_ A better alternative in our opinion to the upstream metric `tekton_pipelines_controller_pipelinerun_duration_seconds_[bucket, sum, count]`
 
@@ -78,7 +78,7 @@ _**PipelineRun Scheduling Duration:**_
 The duration of time in seconds taken for a PipelineRun to be "scheduled", meaning it has been received by the Tekton controller.  It is calculated as the difference between the creation timestamp and the start time of the PipelineRun, where the start time is set by the Tekton controller on the initial event received for the creation of the PipelineRun.  It is a good indication of how quickly the API server sends create events to the Tekton controller.
 
 _Metric Name:_ `pipelinerun_duration_scheduled_seconds`
-_Labels:_ a `namespace` label and the `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.
+_Labels:_ a `namespace` label.
 _Data Type:_ Histogram
 _Description:_ The time taken in seconds for a PipelineRun to be "scheduled", meaning it has been received by the Tekton controller.
 
@@ -86,7 +86,7 @@ _**TaskRun Scheduling Duration:**_
 The duration of time in seconds taken for a TaskRun to be "scheduled", meaning it has been received by the Tekton controller.  It is calculated as the difference between the creation timestamp and the start time of the TaskRun, where the start time is set by the Tekton controller on the initial event received for the creation of the TaskRun.  It is a good indication of how quickly the API server sends create events to the Tekton controller.
 
 _Metric Name:_ `taskrun_duration_scheduled_seconds`
-_Labels:_ a `namespace` label and the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
+_Labels:_ a `namespace` label.
 _Data Type:_ Histogram
 _Description:_ The time taken in seconds for a TaskRun to be "scheduled", meaning it has been received by the Tekton controller.
 
@@ -95,7 +95,7 @@ _**Scheduling Duration of different TaskRuns with a PipelineRun:**_
 The time taken in milliseconds between the creation of the first TaskRun(s) and the creation of its PipelineRun, followed by the duration in milliseconds between the completion of a preceding TaskRun and the creation of the following TaskRun.  This metrics accounts for both sequential TaskRuns, parallel TaskRuns that start off a PipelineRun, and ending TaskRuns that depend on multiple TaskRun chains that run in parallel.
 
 _Metric Name:_ `pipelinerun_gap_between_taskruns_milliseconds`
-_Labels:_ Minimally a `namespace` label.  If the `ENABLE_GAP_METRIC_ADDITIONAL_LABELS` environment variable is set to `true` on the exporter deployment, the `pipelinename`, `completed`, and `upcoming` labels are set.  The `pipelinename` label is set to the name of the Pipeline if its reference is set, otherwise the name of the PipelineRun.  The `completed` label is set either the Pipeline name if we are dealing with the first TaskRun, or the name of the latest Task for the TaskRun to be completed.  The `upcoming` label is set to the name of the Task of the TaskRun that is created but not yet complete.
+_Labels:_ Minimally a `namespace` label.  
 _Data Type_: Histogram
 _Description_: The taken between TaskRuns within a PipelineRun
 
@@ -103,7 +103,7 @@ _**Scheduling Duration that a TaskRun Pod is recognized by the Kubelet:**_
 The time taken in milliseconds between the creation of a Pod, where the Pod start time is set once the kubelet has acknowledged the pod, but has not yet pulled its images.
 
 _Metric Name:_ `taskrun_pod_duration_kubelet_acknowledged_milliseconds`
-_Labels:_ a `namespace` label and the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
+_Labels:_ a `namespace` label.
 _Data Type_: Histogram
 _Description_: Duration in milliseconds between the pod creation time and pod start time
 
@@ -111,7 +111,7 @@ _**Scheduling Duration that a TaskRun Pod's images are pulled by the Kubelet and
 The time taken in milliseconds between the pod start time and the first container to start. This should include any overhead to pull container images, plus any kubelet to linux scheduling overhead.
 
 _Metric Name:_ `taskrun_pod_duration_kubelet_to_container_start_milliseconds`
-_Labels:_ a `namespace` label and the `taskname` label is set to the name of the Task if its reference is set, otherwise the name of the TaskRun.
+_Labels:_ a `namespace` label.
 _Data Type_: Histogram
 _Description_: Duration in milliseconds between the pod start time and the first container to start.
 


### PR DESCRIPTION
there proved to be too many edge cases where pipeline or task name would actually be the dynamically generated pipelinerun name or taskrun name, which adversely affected metric cardinality.

prometheus scraping on prod-rh01 started to timeout becase there were too many entries to return

restarting the instance alleviated things for now, but we need to avoid this moving forward.

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED