### PR TITLE
SRVKP-4523: add throttled check to deadlock checks

### DIFF
--- a/collector/waiting_on_pipelinerun_kickoff_test.go
+++ b/collector/waiting_on_pipelinerun_kickoff_test.go
@@ -202,16 +202,16 @@ func TestPipelineRunKickoffStats(t *testing.T) {
 	// initiate second scan (where repeats mean bump the metric)
 	reconciler.resetPipelineRunKickoffStats(ctx)
 	label := prometheus.Labels{NS_LABEL: "test-namespace"}
-	validateGaugeVec(t, reconciler.waitPRKickoffCollector.waitPipelineRunKickoff, label, float64(2))
-	// third pass should reset and still be two
+	validateGaugeVec(t, reconciler.waitPRKickoffCollector.waitPipelineRunKickoff, label, float64(1))
+	// third pass should reset and still be one
 	reconciler.resetPipelineRunKickoffStats(ctx)
-	validateGaugeVec(t, reconciler.waitPRKickoffCollector.waitPipelineRunKickoff, label, float64(2))
-	// deletion, then another pass, should now be one
+	validateGaugeVec(t, reconciler.waitPRKickoffCollector.waitPipelineRunKickoff, label, float64(1))
+	// deletion, then another pass, should now be zero
 	err := c.Delete(ctx, mockPipelineRuns[1])
 	assert.NoError(t, err)
 	reconciler.resetPipelineRunKickoffStats(ctx)
-	validateGaugeVec(t, reconciler.waitPRKickoffCollector.waitPipelineRunKickoff, label, float64(1))
-	// change the last remaining one so it passes, should now be zero
+	validateGaugeVec(t, reconciler.waitPRKickoffCollector.waitPipelineRunKickoff, label, float64(0))
+	// change the last remaining one so it passes, should still be zero
 	mockPipelineRuns[2].Status.StartTime = &metav1.Time{time.Now()}
 	err = c.Update(ctx, mockPipelineRuns[2])
 	assert.NoError(t, err)

--- a/collector/waiting_on_pod_create_attempt_test.go
+++ b/collector/waiting_on_pod_create_attempt_test.go
@@ -125,15 +125,15 @@ func TestResetPodCreateAttemptedStats(t *testing.T) {
 	// initiate second scan (where repeats mean bump the metric)
 	reconciler.resetPodCreateAttemptedStats(ctx)
 	label := prometheus.Labels{NS_LABEL: "test-namespace"}
-	validateGaugeVec(t, reconciler.waitPodCollector.waitPodCreate, label, float64(2))
-	// third pass should reset and still be two
+	validateGaugeVec(t, reconciler.waitPodCollector.waitPodCreate, label, float64(1))
+	// third pass should reset and still be one
 	reconciler.resetPodCreateAttemptedStats(ctx)
-	validateGaugeVec(t, reconciler.waitPodCollector.waitPodCreate, label, float64(2))
-	// deletion, then another pass, should now be one
+	validateGaugeVec(t, reconciler.waitPodCollector.waitPodCreate, label, float64(1))
+	// deletion, then another pass, should still be zero
 	err := c.Delete(ctx, mockTaskRuns[1])
 	assert.NoError(t, err)
 	reconciler.resetPodCreateAttemptedStats(ctx)
-	validateGaugeVec(t, reconciler.waitPodCollector.waitPodCreate, label, float64(1))
+	validateGaugeVec(t, reconciler.waitPodCollector.waitPodCreate, label, float64(0))
 	// change the last remaining one so it passes, should now be zero
 	mockTaskRuns[2].ObjectMeta.Annotations = map[string]string{pod.ReleaseAnnotation: "foo"}
 	err = c.Update(ctx, mockTaskRuns[2])


### PR DESCRIPTION
after more monitoring of konflux prod over the last few weeks occasional bumps in the deadock metric per prometheus monitoring have conincided with k8s throttling

adding check like with the other alert metrics

our alerts will also includesum(pv_collector_bound_pvc_count{exported_namespace=~".+-tenant"}) == 0  to confirm that any pods that were started before a deadlock have completed

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED