### PR TITLE
SRVKP-4532: add pending resolution request metrid

### DIFF
--- a/collector/waiting_on_resolutionrequest.go
+++ b/collector/waiting_on_resolutionrequest.go
@@ -1,0 +1,80 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"knative.dev/pkg/apis"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+type WaitingOnResolutionRequestCollector struct {
+	waitingResolutionRequest *prometheus.GaugeVec
+}
+
+func NewWaitingOnResolutionRequestCollector() *WaitingOnResolutionRequestCollector {
+	labelNames := []string{NS_LABEL}
+	waitingResolutionRequest := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pending_resolutionrequest_count",
+		Help: "Number of uncompleted ResolutionRequests for multiple scan iterations",
+	}, labelNames)
+	waitingOnResolutionRequestCollector := &WaitingOnResolutionRequestCollector{
+		waitingResolutionRequest: waitingResolutionRequest,
+	}
+	metrics.Registry.Register(waitingResolutionRequest)
+	return waitingOnResolutionRequestCollector
+}
+
+func (c *WaitingOnResolutionRequestCollector) IncCollector(ns string) {
+	labels := map[string]string{NS_LABEL: ns}
+	c.waitingResolutionRequest.With(labels).Inc()
+}
+
+func (c *WaitingOnResolutionRequestCollector) ZeroCollector(ns string) {
+	labels := map[string]string{NS_LABEL: ns}
+	c.waitingResolutionRequest.With(labels).Set(float64(0))
+}
+
+func (r *ExporterReconcile) resetResoultionRequestsStats(ctx context.Context) {
+	cacheCopy := buildLastScanCopy(r.waitRRCollector, r.waitRRCache)
+
+	// however, we'll clear out cache to avoid long term accumulation, memory leak, as things like dynamically created test namespaces
+	// accumulate
+	r.waitRRCache = map[string]map[string]struct{}{}
+
+	rrList := &v1beta1.ResolutionRequestList{}
+	err := r.client.List(ctx, rrList)
+	deadlockTracker := &DeadlockTracker{
+		collector:         r.waitRRCollector,
+		filter:            r.pipelineRunKickoffNamespaceFilter,
+		flaggedNamespaces: map[string]struct{}{},
+		lastScan:          cacheCopy,
+		currentScan:       r.waitRRCache,
+	}
+	if err == nil {
+		for _, rr := range rrList.Items {
+			deadlockTracker.deadlocked = func() bool {
+				if rr.IsDone() {
+					return false
+				}
+
+				if rr.Status.GetCondition(apis.ConditionSucceeded) != nil {
+					return false
+				}
+
+				controllerLog.Info(fmt.Sprintf("resoultionrequest not started %s:%s, %s", rr.Namespace, rr.Name, createJSONFormattedString(rr)))
+				return true
+
+			}
+			deadlockTracker.PerformDeadlockDetection(rr.Name, rr.Namespace)
+		}
+	} else {
+		controllerLog.Error(err, "resolutionrequest query for kickoff attempts failed with an error")
+	}
+
+	// if a namespace is in the cache, but not our most recent scan, zero it out too, as the namespace is either
+	// deleted or has all its PipelineRuns and owned objects like ResoulutionRequests pruned.
+	zeroOutPriorHitNamespacesThatAreNowEmpty(r.waitRRCollector, cacheCopy, r.waitRRCache)
+}

--- a/collector/waiting_on_resolutionrequest_test.go
+++ b/collector/waiting_on_resolutionrequest_test.go
@@ -1,0 +1,76 @@
+package collector
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestResolutionRequestsStats(t *testing.T) {
+	objs := []client.Object{}
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	mockResolutionRequests := []*v1beta1.ResolutionRequest{
+		// should bump the counter
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-1"},
+			Status:     v1beta1.ResolutionRequestStatus{},
+		},
+		// should bump the counter
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-2"},
+			Status:     v1beta1.ResolutionRequestStatus{},
+		},
+		// should not bump the counter
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-3"},
+			Status: v1beta1.ResolutionRequestStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						apis.Condition{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.TODO()
+	for _, rr := range mockResolutionRequests {
+		err := c.Create(ctx, rr)
+		assert.NoError(t, err)
+	}
+
+	reconciler := buildReconciler(c, nil, nil)
+	// initiate first scan
+	reconciler.resetResoultionRequestsStats(ctx)
+	// initiate second scan (where repeats mean bump the metric)
+	reconciler.resetResoultionRequestsStats(ctx)
+	label := prometheus.Labels{NS_LABEL: "test-namespace"}
+	validateGaugeVec(t, reconciler.waitRRCollector.waitingResolutionRequest, label, float64(2))
+	// third pass should reset and still be one
+	reconciler.resetResoultionRequestsStats(ctx)
+	validateGaugeVec(t, reconciler.waitRRCollector.waitingResolutionRequest, label, float64(2))
+	// deletion, then another pass, should now be zero
+	err := c.Delete(ctx, mockResolutionRequests[0])
+	assert.NoError(t, err)
+	// third pass should reset and still be one
+	reconciler.resetResoultionRequestsStats(ctx)
+	validateGaugeVec(t, reconciler.waitRRCollector.waitingResolutionRequest, label, float64(1))
+
+}

--- a/docs/metrics-specification.md
+++ b/docs/metrics-specification.md
@@ -66,6 +66,14 @@ _Labels:_ `namespace` label.
 _Data Type:_ Gauge
 _Description:_ Number of TaskRuns where the Tekton Controller has yet to attempt to create its underlying Pod, or the TaskRun is still in Pending state, for multiple scan iterations.
 
+_**Pending ResolutionRequests Yet To Be Attempted**_  
+The number of ResolutionRequests where the Resolver Controller has yet to attempt to initiate retrieval for multiple scan iterations.
+
+_Metric Name:_ `pending_resolutionrequest_count`
+_Labels:_ `namespace` label.  
+_Data Type:_ Gauge
+_Description:_ Number of ResolutionRequests where the Resolver Controller has yet to initiate retrieval for multiple scan iterations.
+
 _**PipelineRun Yet To Kick Off:**_  
 The number of PipelineRuns where the Tekton Controller has yet to attempt to process its correctly defined Task specifications for multiple scan iterations.
 


### PR DESCRIPTION
New resolver deadlock metric given recent hangs/crashloops

Note - since there is not metrics initialization/use in the remote resolver currently, starting downstream given konflux need, and to vet the metrics before potential upstreaming.

@enarha @savitaashture @khrm @divyansh42 FYI / PTAL minimally for education purposes

Successfully tested locally:

![pending-resolution-requests](https://github.com/user-attachments/assets/108eb8a7-8b42-4bed-bef2-60e142cb91cc)


rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED